### PR TITLE
Revert setup-php to v2 tag SHA to fix CI 401 errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2
+        uses: shivammathur/setup-php@d59004228537ca90c8dca680592a08a675bf52b6 # v2
         with:
           php-version: ${{ matrix.php-version }}
           tools: composer
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2
+        uses: shivammathur/setup-php@d59004228537ca90c8dca680592a08a675bf52b6 # v2
         with:
           php-version: '8.2'
           tools: composer
@@ -80,7 +80,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2
+        uses: shivammathur/setup-php@d59004228537ca90c8dca680592a08a675bf52b6 # v2
         with:
           php-version: '8.2'
           tools: composer
@@ -130,7 +130,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y subversion
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2
+        uses: shivammathur/setup-php@d59004228537ca90c8dca680592a08a675bf52b6 # v2
         with:
           php-version: ${{ matrix.php-version }}
           extensions: mysqli

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2
+        uses: shivammathur/setup-php@d59004228537ca90c8dca680592a08a675bf52b6 # v2
         with:
           php-version: '8.2'
           tools: composer


### PR DESCRIPTION
## Summary
- Dependabot bumped `shivammathur/setup-php` to commit `44454db` — a non-release commit on the repo's default branch
- GitHub Actions returns **401 Unauthorized** when downloading that commit's tarball, breaking all CI runs on main
- Reverts to the stable `v2` tag SHA (`d590042`) which is known to work

## Test plan
- [ ] All CI jobs pass (no 401 download errors)
- [ ] PHPCS, PHPStan, Rector, and PHPUnit all green

## Summary by Sourcery

Revert GitHub Actions workflows to use a stable shivammathur/setup-php v2 commit to restore reliable CI and release pipelines.

CI:
- Pin setup-php in CI workflows to a known-good v2 commit SHA to avoid unauthorized tarball download failures.

Deployment:
- Pin setup-php in release workflow to the same stable v2 commit SHA to prevent release job failures.