### PR TITLE
Fix collector registration order: Block_Editor before Network_Connectivity

### DIFF
--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -126,8 +126,8 @@ class Plugin {
 			new Collectors\Media_Uploads(),
 			new Collectors\Performance(),
 			new Collectors\Update_Health(),
-			new Collectors\Network_Connectivity(),
 			new Collectors\Block_Editor(),
+			new Collectors\Network_Connectivity(),
 		);
 
 		foreach ( $collectors as $collector ) {

--- a/tests/CollectorsTest.php
+++ b/tests/CollectorsTest.php
@@ -55,8 +55,8 @@ class CollectorsTest extends WP_UnitTestCase {
 			'media_uploads',
 			'performance',
 			'update_health',
-			'network_connectivity',
 			'block_editor',
+			'network_connectivity',
 		);
 
 		foreach ( $expected_ids as $id ) {
@@ -498,43 +498,6 @@ class CollectorsTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that the Network & Connectivity collector returns expected fields.
-	 */
-	public function test_network_connectivity_has_expected_fields() {
-		$collector = $this->collectors['network_connectivity'];
-		$fields    = $collector->collect();
-		$labels    = wp_list_pluck( $fields, 'label' );
-
-		$this->assertContains( 'WordPress.org API', $labels );
-		$this->assertContains( 'WordPress.org Downloads', $labels );
-		$this->assertContains( 'Loopback Request', $labels );
-		$this->assertContains( 'HTTP Proxy', $labels );
-		$this->assertContains( 'HTTP Transport', $labels );
-		$this->assertContains( 'SSL Certificate', $labels );
-		$this->assertContains( 'SSL Verification', $labels );
-		$this->assertContains( 'External HTTP Blocked', $labels );
-		$this->assertContains( 'DNS Resolution', $labels );
-		$this->assertContains( 'cURL Version', $labels );
-	}
-
-	/**
-	 * Test that the Network & Connectivity collector caching works.
-	 */
-	public function test_network_connectivity_caching() {
-		$collector = $this->collectors['network_connectivity'];
-
-		delete_transient( 'sr_network_connectivity' );
-
-		$data1 = $collector->get_cached_data();
-		$this->assertIsArray( $data1 );
-
-		$cached = get_transient( 'sr_network_connectivity' );
-		$this->assertNotFalse( $cached );
-
-		delete_transient( 'sr_network_connectivity' );
-	}
-
-	/**
 	 * Test that the Block Editor collector returns expected fields.
 	 */
 	public function test_block_editor_has_expected_fields() {
@@ -569,5 +532,42 @@ class CollectorsTest extends WP_UnitTestCase {
 		$this->assertNotFalse( $cached );
 
 		delete_transient( 'sr_block_editor' );
+	}
+
+	/**
+	 * Test that the Network & Connectivity collector returns expected fields.
+	 */
+	public function test_network_connectivity_has_expected_fields() {
+		$collector = $this->collectors['network_connectivity'];
+		$fields    = $collector->collect();
+		$labels    = wp_list_pluck( $fields, 'label' );
+
+		$this->assertContains( 'WordPress.org API', $labels );
+		$this->assertContains( 'WordPress.org Downloads', $labels );
+		$this->assertContains( 'Loopback Request', $labels );
+		$this->assertContains( 'HTTP Proxy', $labels );
+		$this->assertContains( 'HTTP Transport', $labels );
+		$this->assertContains( 'SSL Certificate', $labels );
+		$this->assertContains( 'SSL Verification', $labels );
+		$this->assertContains( 'External HTTP Blocked', $labels );
+		$this->assertContains( 'DNS Resolution', $labels );
+		$this->assertContains( 'cURL Version', $labels );
+	}
+
+	/**
+	 * Test that the Network & Connectivity collector caching works.
+	 */
+	public function test_network_connectivity_caching() {
+		$collector = $this->collectors['network_connectivity'];
+
+		delete_transient( 'sr_network_connectivity' );
+
+		$data1 = $collector->get_cached_data();
+		$this->assertIsArray( $data1 );
+
+		$cached = get_transient( 'sr_network_connectivity' );
+		$this->assertNotFalse( $cached );
+
+		delete_transient( 'sr_network_connectivity' );
 	}
 }


### PR DESCRIPTION
## Summary
- Corrects the collector registration order in `class-plugin.php` so Block_Editor comes before Network_Connectivity
- Updates the expected_ids array in `tests/CollectorsTest.php` to match the correct order
- Reorders corresponding test methods to follow the collector registration sequence

The intended order ends with: ...Email_Delivery, Media_Uploads, Performance, Update_Health, Block_Editor, Network_Connectivity.

This was incorrectly ordered when PR #22 was merged with the conflict resolution having Network_Connectivity before Block_Editor.

## Test plan
- [ ] Verify PHPCS passes
- [ ] Verify PHPStan passes  
- [ ] Verify Rector dry-run passes
- [ ] Verify collector registration order matches specification

## Summary by Sourcery

Align collector registration order so the Block Editor collector is registered before the Network Connectivity collector across code and tests.

Bug Fixes:
- Correct collector registration sequence so Block_Editor precedes Network_Connectivity as intended.

Tests:
- Update expected collector IDs and reorder Network Connectivity tests to match the corrected registration order.