### PR TITLE
Add Autoload Optimizer fixer (Phase 3.1)

### DIFF
--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -37,6 +37,11 @@ class Plugin {
 	private \SystemReport\REST_Controller $rest_controller;
 
 	/**
+	 * Fixer registry instance.
+	 */
+	private \SystemReport\Fixer_Registry $fixer_registry;
+
+	/**
 	 * Error log reader instance.
 	 */
 	private \SystemReport\Error_Log_Reader $error_log_reader;
@@ -89,6 +94,7 @@ class Plugin {
 	 */
 	private function __construct() {
 		$this->report_generator     = new Report_Generator();
+		$this->fixer_registry       = new Fixer_Registry();
 		$this->admin_page           = new Admin_Page( $this->report_generator );
 		$this->rest_controller      = new REST_Controller( $this->report_generator );
 		$this->error_log_reader     = new Error_Log_Reader();
@@ -97,6 +103,7 @@ class Plugin {
 		$this->github_updater       = new GitHub_Updater( WP_SYSTEM_REPORT_FILE );
 
 		$this->register_default_collectors();
+		$this->register_default_fixers();
 		$this->register_hooks();
 	}
 
@@ -132,6 +139,19 @@ class Plugin {
 
 		foreach ( $collectors as $collector ) {
 			$this->report_generator->register_collector( $collector );
+		}
+	}
+
+	/**
+	 * Register all default fixers.
+	 */
+	private function register_default_fixers(): void {
+		$fixers = array(
+			new Fixers\Autoload_Optimizer(),
+		);
+
+		foreach ( $fixers as $fixer ) {
+			$this->fixer_registry->register( $fixer );
 		}
 	}
 
@@ -173,6 +193,15 @@ class Plugin {
  */
 	public function get_report_generator(): \SystemReport\Report_Generator {
 		return $this->report_generator;
+	}
+
+	/**
+	 * Get the fixer registry.
+	 *
+	 * @return Fixer_Registry The fixer registry instance.
+	 */
+	public function get_fixer_registry(): Fixer_Registry {
+		return $this->fixer_registry;
 	}
 
 	/**

--- a/includes/fixers/class-autoload-optimizer.php
+++ b/includes/fixers/class-autoload-optimizer.php
@@ -1,0 +1,415 @@
+<?php
+/**
+ * Autoload optimizer fixer.
+ *
+ * @package SystemReport
+ */
+
+namespace SystemReport\Fixers;
+
+use SystemReport\Fixer;
+use SystemReport\Fix_Result;
+use SystemReport\Risk_Level;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Optimizes the wp_options autoload column by disabling autoload
+ * for options whose serialized values exceed a configurable threshold.
+ *
+ * WordPress autoloads every option flagged with autoload='yes' on
+ * every page request. Large options (often transient data, plugin
+ * caches, or serialized settings) can dramatically increase memory
+ * usage and slow response times. This fixer switches oversized
+ * options to autoload='no' so they are loaded on demand instead.
+ */
+class Autoload_Optimizer implements Fixer {
+
+	/**
+	 * Default minimum byte threshold for an option to be considered bloated.
+	 *
+	 * Options with a serialized value equal to or larger than this size
+	 * will be switched to autoload='no'.
+	 *
+	 * @var int
+	 */
+	private const DEFAULT_THRESHOLD = 100 * 1024; // 100 KB.
+
+	/**
+	 * WordPress core options that must always be autoloaded.
+	 *
+	 * These options are loaded early in the WordPress bootstrap process
+	 * and disabling autoload could break the site.
+	 *
+	 * @var string[]
+	 */
+	private const PROTECTED_OPTIONS = array(
+		'siteurl',
+		'home',
+		'blogname',
+		'blogdescription',
+		'users_can_register',
+		'admin_email',
+		'start_of_week',
+		'use_balanceTags',
+		'use_smilies',
+		'require_name_email',
+		'comments_notify',
+		'posts_per_rss',
+		'rss_use_excerpt',
+		'mailserver_url',
+		'mailserver_login',
+		'mailserver_pass',
+		'mailserver_port',
+		'default_category',
+		'default_comment_status',
+		'default_ping_status',
+		'default_pingback_flag',
+		'posts_per_page',
+		'date_format',
+		'time_format',
+		'links_updated_date_format',
+		'comment_moderation',
+		'moderation_notify',
+		'permalink_structure',
+		'rewrite_rules',
+		'hack_file',
+		'blog_charset',
+		'moderation_keys',
+		'active_plugins',
+		'category_base',
+		'ping_sites',
+		'comment_max_links',
+		'gmt_offset',
+		'default_email_category',
+		'recently_edited',
+		'template',
+		'stylesheet',
+		'comment_registration',
+		'html_type',
+		'default_role',
+		'db_version',
+		'uploads_use_yearmonth_folders',
+		'upload_path',
+		'blog_public',
+		'default_link_category',
+		'show_on_front',
+		'tag_base',
+		'show_avatars',
+		'avatar_rating',
+		'upload_url_path',
+		'thumbnail_size_w',
+		'thumbnail_size_h',
+		'thumbnail_crop',
+		'medium_size_w',
+		'medium_size_h',
+		'avatar_default',
+		'large_size_w',
+		'large_size_h',
+		'image_default_link_type',
+		'image_default_size',
+		'image_default_align',
+		'close_comments_for_old_posts',
+		'close_comments_days_old',
+		'thread_comments',
+		'thread_comments_depth',
+		'page_comments',
+		'comments_per_page',
+		'default_comments_page',
+		'comment_order',
+		'sticky_posts',
+		'widget_categories',
+		'widget_text',
+		'widget_rss',
+		'uninstall_plugins',
+		'timezone_string',
+		'page_for_posts',
+		'page_on_front',
+		'default_post_format',
+		'link_manager_enabled',
+		'finished_splitting_shared_terms',
+		'site_icon',
+		'medium_large_size_w',
+		'medium_large_size_h',
+		'wp_page_for_privacy_policy',
+		'show_comments_cookies_opt_in',
+		'admin_email_lifespan',
+		'initial_db_version',
+		'wp_user_roles',
+		'WPLANG',
+		'new_admin_email',
+		'fresh_site',
+		'auto_update_core_dev',
+		'auto_update_core_minor',
+		'auto_update_core_major',
+		'wp_force_deactivated_plugins',
+		'wp_attachment_pages_enabled',
+	);
+
+	/**
+	 * Byte threshold for this instance.
+	 */
+	private int $threshold;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param int|null $threshold Optional custom threshold in bytes.
+	 */
+	public function __construct( ?int $threshold = null ) {
+		$this->threshold = $threshold ?? self::DEFAULT_THRESHOLD;
+	}
+
+	/**
+	 * Get the unique slug identifier for this fixer.
+	 *
+	 * @return string Fixer ID.
+	 */
+	public function get_id(): string {
+		return 'autoload_optimizer';
+	}
+
+	/**
+	 * Get the human-readable display label.
+	 *
+	 * @return string Translated display name.
+	 */
+	public function get_label(): string {
+		return __( 'Autoload Optimizer', 'wp-system-report' );
+	}
+
+	/**
+	 * Get a description of what this fixer does.
+	 *
+	 * @return string Translated description.
+	 */
+	public function get_description(): string {
+		return __( 'Disables autoload for oversized options to reduce memory usage on every page load.', 'wp-system-report' );
+	}
+
+	/**
+	 * Get the risk level of this operation.
+	 *
+	 * @return Risk_Level Risk level enum case.
+	 */
+	public function get_risk_level(): Risk_Level {
+		return Risk_Level::Medium;
+	}
+
+	/**
+	 * Get the category this fixer belongs to.
+	 *
+	 * @return string Category slug.
+	 */
+	public function get_category(): string {
+		return 'performance';
+	}
+
+	/**
+	 * Check if this fix is applicable.
+	 *
+	 * Returns true when at least one non-protected autoloaded option
+	 * exceeds the configured threshold.
+	 *
+	 * @return bool Whether the fix can be applied.
+	 */
+	public function can_fix(): bool {
+		$bloated = $this->get_bloated_options();
+		return count( $bloated ) > 0;
+	}
+
+	/**
+	 * Execute the autoload optimization.
+	 *
+	 * Identifies all non-protected autoloaded options exceeding the
+	 * threshold and switches them to autoload='no'.
+	 *
+	 * @return Fix_Result Result with before/after snapshots.
+	 */
+	public function fix(): Fix_Result {
+		$bloated = $this->get_bloated_options();
+
+		if ( empty( $bloated ) ) {
+			return Fix_Result::success(
+				__( 'No oversized autoloaded options found. Nothing to optimize.', 'wp-system-report' )
+			);
+		}
+
+		$before = array(
+			'total_autoload_size' => $this->get_total_autoload_size(),
+			'bloated_options'     => $this->format_options_snapshot( $bloated ),
+			'bloated_count'       => count( $bloated ),
+		);
+
+		$optimized = array();
+		$errors    = array();
+
+		foreach ( $bloated as $option ) {
+			$result = $this->disable_autoload( $option->option_name );
+
+			if ( $result ) {
+				$optimized[] = $option->option_name;
+			} else {
+				$errors[] = sprintf(
+					/* translators: %s: option name */
+					__( 'Failed to update autoload for: %s', 'wp-system-report' ),
+					$option->option_name
+				);
+			}
+		}
+
+		// Clear the alloptions cache so WordPress picks up the changes.
+		wp_cache_delete( 'alloptions', 'options' );
+
+		$after = array(
+			'total_autoload_size' => $this->get_total_autoload_size(),
+			'optimized_options'   => $optimized,
+			'optimized_count'     => count( $optimized ),
+		);
+
+		if ( ! empty( $errors ) ) {
+			return Fix_Result::failure(
+				sprintf(
+					/* translators: 1: number of successful optimizations, 2: number of failures */
+					__( 'Partially completed: %1$d option(s) optimized, %2$d failed.', 'wp-system-report' ),
+					count( $optimized ),
+					count( $errors )
+				),
+				$errors
+			);
+		}
+
+		return Fix_Result::success(
+			sprintf(
+				/* translators: %d: number of options optimized */
+				__( 'Successfully disabled autoload for %d oversized option(s).', 'wp-system-report' ),
+				count( $optimized )
+			),
+			$before,
+			$after
+		);
+	}
+
+	/**
+	 * Get the threshold in bytes.
+	 *
+	 * @return int Current threshold.
+	 */
+	public function get_threshold(): int {
+		/**
+		 * Filter the autoload optimization threshold.
+		 *
+		 * @param int $threshold Minimum byte size for an option to be considered bloated.
+		 */
+		return (int) apply_filters( 'wp_system_report_autoload_threshold', $this->threshold );
+	}
+
+	/**
+	 * Query for autoloaded options that exceed the threshold.
+	 *
+	 * @return object[] Array of database row objects with option_name and val_size properties.
+	 */
+	private function get_bloated_options(): array {
+		global $wpdb;
+
+		$threshold = $this->get_threshold();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Diagnostic query, no suitable cache.
+		$results = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT option_name, LENGTH(option_value) AS val_size
+				FROM {$wpdb->options}
+				WHERE autoload IN ('yes', 'on')
+				AND LENGTH(option_value) >= %d
+				ORDER BY val_size DESC",
+				$threshold
+			)
+		);
+
+		if ( ! $results ) {
+			return array();
+		}
+
+		return array_filter(
+			$results,
+			function ( object $row ): bool {
+				return ! $this->is_protected( $row->option_name );
+			}
+		);
+	}
+
+	/**
+	 * Check if an option name is protected from optimization.
+	 *
+	 * @param string $option_name Option name to check.
+	 * @return bool True if the option must not be modified.
+	 */
+	private function is_protected( string $option_name ): bool {
+		if ( in_array( $option_name, self::PROTECTED_OPTIONS, true ) ) {
+			return true;
+		}
+
+		/**
+		 * Filter whether an option should be protected from autoload optimization.
+		 *
+		 * @param bool   $is_protected Whether the option is protected.
+		 * @param string $option_name  The option name being checked.
+		 */
+		return (bool) apply_filters( 'wp_system_report_autoload_protected', false, $option_name );
+	}
+
+	/**
+	 * Disable autoload for a single option.
+	 *
+	 * @param string $option_name Option to modify.
+	 * @return bool True on success, false on failure.
+	 */
+	private function disable_autoload( string $option_name ): bool {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Targeted update, no cache.
+		$result = $wpdb->update(
+			$wpdb->options,
+			array( 'autoload' => 'no' ),
+			array( 'option_name' => $option_name ),
+			array( '%s' ),
+			array( '%s' )
+		);
+
+		return false !== $result;
+	}
+
+	/**
+	 * Get the total size of all autoloaded option values.
+	 *
+	 * @return int Total size in bytes.
+	 */
+	private function get_total_autoload_size(): int {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Diagnostic query, no suitable cache.
+		$size = $wpdb->get_var(
+			"SELECT SUM(LENGTH(option_value))
+			FROM {$wpdb->options}
+			WHERE autoload IN ('yes', 'on')"
+		);
+
+		return (int) $size;
+	}
+
+	/**
+	 * Format a list of bloated options for a snapshot.
+	 *
+	 * @param object[] $options Array of option row objects.
+	 * @return array<string, int> Associative array of option_name => size_in_bytes.
+	 */
+	private function format_options_snapshot( array $options ): array {
+		$snapshot = array();
+
+		foreach ( $options as $option ) {
+			$snapshot[ $option->option_name ] = (int) $option->val_size;
+		}
+
+		return $snapshot;
+	}
+}

--- a/tests/FixersTest.php
+++ b/tests/FixersTest.php
@@ -1,0 +1,402 @@
+<?php
+/**
+ * Tests for the fixer infrastructure and individual fixers.
+ *
+ * @package SystemReport
+ */
+
+use SystemReport\Fix_Result;
+use SystemReport\Fixer_Registry;
+use SystemReport\Fixers\Autoload_Optimizer;
+use SystemReport\Risk_Level;
+
+/**
+ * Fixer tests.
+ */
+class FixersTest extends WP_UnitTestCase {
+
+	/**
+	 * Fixer registry instance.
+	 *
+	 * @var Fixer_Registry
+	 */
+	private Fixer_Registry $registry;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		$this->registry = new Fixer_Registry();
+	}
+
+	// -------------------------------------------------------
+	// Fix_Result value object tests.
+	// -------------------------------------------------------
+
+	/**
+	 * Test Fix_Result::success() factory method.
+	 */
+	public function test_fix_result_success() {
+		$result = Fix_Result::success(
+			'All good',
+			array( 'count' => 5 ),
+			array( 'count' => 0 )
+		);
+
+		$this->assertTrue( $result->success );
+		$this->assertSame( 'All good', $result->message );
+		$this->assertSame( array( 'count' => 5 ), $result->before );
+		$this->assertSame( array( 'count' => 0 ), $result->after );
+		$this->assertSame( array(), $result->errors );
+	}
+
+	/**
+	 * Test Fix_Result::failure() factory method.
+	 */
+	public function test_fix_result_failure() {
+		$result = Fix_Result::failure(
+			'Something failed',
+			array( 'Database error' )
+		);
+
+		$this->assertFalse( $result->success );
+		$this->assertSame( 'Something failed', $result->message );
+		$this->assertSame( array( 'Database error' ), $result->errors );
+		$this->assertSame( array(), $result->before );
+		$this->assertSame( array(), $result->after );
+	}
+
+	/**
+	 * Test Fix_Result JSON serialization.
+	 */
+	public function test_fix_result_json_serializable() {
+		$result = Fix_Result::success( 'Done', array( 'a' => 1 ), array( 'a' => 0 ) );
+		$json   = wp_json_encode( $result );
+		$data   = json_decode( $json, true );
+
+		$this->assertTrue( $data['success'] );
+		$this->assertSame( 'Done', $data['message'] );
+		$this->assertArrayHasKey( 'before', $data );
+		$this->assertArrayHasKey( 'after', $data );
+	}
+
+	/**
+	 * Test Fix_Result to_array excludes empty arrays.
+	 */
+	public function test_fix_result_to_array_excludes_empty() {
+		$result = Fix_Result::success( 'Clean' );
+		$data   = $result->to_array();
+
+		$this->assertArrayHasKey( 'success', $data );
+		$this->assertArrayHasKey( 'message', $data );
+		$this->assertArrayNotHasKey( 'before', $data );
+		$this->assertArrayNotHasKey( 'after', $data );
+		$this->assertArrayNotHasKey( 'errors', $data );
+	}
+
+	// -------------------------------------------------------
+	// Fixer_Registry tests.
+	// -------------------------------------------------------
+
+	/**
+	 * Test registry starts empty.
+	 */
+	public function test_registry_starts_empty() {
+		$this->assertSame( array(), $this->registry->get_all() );
+	}
+
+	/**
+	 * Test registering and retrieving a fixer.
+	 */
+	public function test_registry_register_and_get() {
+		$fixer = new Autoload_Optimizer();
+		$this->registry->register( $fixer );
+
+		$this->assertTrue( $this->registry->has( 'autoload_optimizer' ) );
+		$this->assertSame( $fixer, $this->registry->get( 'autoload_optimizer' ) );
+	}
+
+	/**
+	 * Test retrieving a non-existent fixer returns null.
+	 */
+	public function test_registry_get_returns_null_for_unknown() {
+		$this->assertNull( $this->registry->get( 'nonexistent' ) );
+	}
+
+	/**
+	 * Test has() returns false for unregistered fixer.
+	 */
+	public function test_registry_has_returns_false_for_unknown() {
+		$this->assertFalse( $this->registry->has( 'nonexistent' ) );
+	}
+
+	/**
+	 * Test get_by_category filters correctly.
+	 */
+	public function test_registry_get_by_category() {
+		$fixer = new Autoload_Optimizer();
+		$this->registry->register( $fixer );
+
+		$performance = $this->registry->get_by_category( 'performance' );
+		$security    = $this->registry->get_by_category( 'security' );
+
+		$this->assertCount( 1, $performance );
+		$this->assertSame( $fixer, $performance['autoload_optimizer'] );
+		$this->assertSame( array(), $security );
+	}
+
+	/**
+	 * Test the wp_system_report_fixers filter.
+	 */
+	public function test_registry_filter() {
+		$fixer = new Autoload_Optimizer();
+		$this->registry->register( $fixer );
+
+		add_filter(
+			'wp_system_report_fixers',
+			function ( array $fixers ): array {
+				unset( $fixers['autoload_optimizer'] );
+				return $fixers;
+			}
+		);
+
+		$this->assertSame( array(), $this->registry->get_all() );
+
+		// Clean up.
+		remove_all_filters( 'wp_system_report_fixers' );
+	}
+
+	// -------------------------------------------------------
+	// Autoload_Optimizer fixer metadata tests.
+	// -------------------------------------------------------
+
+	/**
+	 * Test autoload optimizer metadata.
+	 */
+	public function test_autoload_optimizer_metadata() {
+		$fixer = new Autoload_Optimizer();
+
+		$this->assertSame( 'autoload_optimizer', $fixer->get_id() );
+		$this->assertNotEmpty( $fixer->get_label() );
+		$this->assertNotEmpty( $fixer->get_description() );
+		$this->assertSame( 'performance', $fixer->get_category() );
+		$this->assertSame( Risk_Level::Medium, $fixer->get_risk_level() );
+	}
+
+	/**
+	 * Test autoload optimizer default threshold.
+	 */
+	public function test_autoload_optimizer_default_threshold() {
+		$fixer = new Autoload_Optimizer();
+		$this->assertSame( 100 * 1024, $fixer->get_threshold() );
+	}
+
+	/**
+	 * Test autoload optimizer custom threshold.
+	 */
+	public function test_autoload_optimizer_custom_threshold() {
+		$fixer = new Autoload_Optimizer( 50 * 1024 );
+		$this->assertSame( 50 * 1024, $fixer->get_threshold() );
+	}
+
+	/**
+	 * Test autoload optimizer threshold filter.
+	 */
+	public function test_autoload_optimizer_threshold_filter() {
+		$fixer = new Autoload_Optimizer();
+
+		add_filter( 'wp_system_report_autoload_threshold', function (): int {
+			return 200 * 1024;
+		} );
+
+		$this->assertSame( 200 * 1024, $fixer->get_threshold() );
+
+		remove_all_filters( 'wp_system_report_autoload_threshold' );
+	}
+
+	// -------------------------------------------------------
+	// Autoload_Optimizer functional tests.
+	// -------------------------------------------------------
+
+	/**
+	 * Test can_fix returns false when no bloated options exist.
+	 */
+	public function test_autoload_optimizer_can_fix_false_when_clean() {
+		$fixer = new Autoload_Optimizer();
+		// Default options in a fresh WP install are well under 100 KB.
+		$this->assertFalse( $fixer->can_fix() );
+	}
+
+	/**
+	 * Test can_fix returns true when bloated option exists.
+	 */
+	public function test_autoload_optimizer_can_fix_true_when_bloated() {
+		global $wpdb;
+
+		// Insert a large autoloaded option (150 KB).
+		$large_value = str_repeat( 'x', 150 * 1024 );
+		update_option( 'sr_test_bloated_option', $large_value, 'yes' );
+
+		$fixer = new Autoload_Optimizer();
+		$this->assertTrue( $fixer->can_fix() );
+
+		delete_option( 'sr_test_bloated_option' );
+	}
+
+	/**
+	 * Test fix() succeeds and disables autoload for bloated options.
+	 */
+	public function test_autoload_optimizer_fix_disables_autoload() {
+		global $wpdb;
+
+		// Insert a large autoloaded option.
+		$large_value = str_repeat( 'y', 150 * 1024 );
+		update_option( 'sr_test_large_opt', $large_value, 'yes' );
+
+		$fixer  = new Autoload_Optimizer();
+		$result = $fixer->fix();
+
+		$this->assertTrue( $result->success );
+		$this->assertNotEmpty( $result->before );
+		$this->assertNotEmpty( $result->after );
+
+		// Verify the option was switched to no-autoload.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Test assertion query.
+		$autoload = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT autoload FROM {$wpdb->options} WHERE option_name = %s",
+				'sr_test_large_opt'
+			)
+		);
+		$this->assertSame( 'no', $autoload );
+
+		// The before snapshot should include the option.
+		$this->assertArrayHasKey( 'sr_test_large_opt', $result->before['bloated_options'] );
+
+		// The after snapshot should confirm optimization.
+		$this->assertContains( 'sr_test_large_opt', $result->after['optimized_options'] );
+
+		delete_option( 'sr_test_large_opt' );
+	}
+
+	/**
+	 * Test fix() returns success with nothing to do when clean.
+	 */
+	public function test_autoload_optimizer_fix_noop_when_clean() {
+		$fixer  = new Autoload_Optimizer();
+		$result = $fixer->fix();
+
+		$this->assertTrue( $result->success );
+		$this->assertStringContainsString( 'Nothing to optimize', $result->message );
+	}
+
+	/**
+	 * Test fix() does not modify protected WordPress core options.
+	 */
+	public function test_autoload_optimizer_protects_core_options() {
+		global $wpdb;
+
+		// The 'rewrite_rules' option is often large and is protected.
+		// We'll use a low threshold to catch it.
+		$fixer = new Autoload_Optimizer( 1 ); // 1-byte threshold catches everything.
+
+		$result = $fixer->fix();
+
+		// Even with a 1-byte threshold, core options like siteurl must remain autoloaded.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Test assertion query.
+		$autoload = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT autoload FROM {$wpdb->options} WHERE option_name = %s",
+				'siteurl'
+			)
+		);
+		$this->assertNotSame( 'no', $autoload );
+	}
+
+	/**
+	 * Test the protected option filter.
+	 */
+	public function test_autoload_optimizer_protected_filter() {
+		global $wpdb;
+
+		// Insert a large option.
+		$large_value = str_repeat( 'z', 150 * 1024 );
+		update_option( 'sr_test_protected_opt', $large_value, 'yes' );
+
+		// Mark it as protected via filter.
+		add_filter(
+			'wp_system_report_autoload_protected',
+			function ( bool $protected, string $name ): bool {
+				if ( 'sr_test_protected_opt' === $name ) {
+					return true;
+				}
+				return $protected;
+			},
+			10,
+			2
+		);
+
+		$fixer = new Autoload_Optimizer();
+		// It should not be fixable because the only bloated option is protected.
+		$this->assertFalse( $fixer->can_fix() );
+
+		remove_all_filters( 'wp_system_report_autoload_protected' );
+		delete_option( 'sr_test_protected_opt' );
+	}
+
+	/**
+	 * Test fix() handles multiple bloated options.
+	 */
+	public function test_autoload_optimizer_fixes_multiple_options() {
+		// Insert two large autoloaded options.
+		update_option( 'sr_test_multi_a', str_repeat( 'a', 150 * 1024 ), 'yes' );
+		update_option( 'sr_test_multi_b', str_repeat( 'b', 200 * 1024 ), 'yes' );
+
+		$fixer  = new Autoload_Optimizer();
+		$result = $fixer->fix();
+
+		$this->assertTrue( $result->success );
+		$this->assertSame( 2, $result->after['optimized_count'] );
+		$this->assertContains( 'sr_test_multi_a', $result->after['optimized_options'] );
+		$this->assertContains( 'sr_test_multi_b', $result->after['optimized_options'] );
+
+		// Verify the total autoload size decreased.
+		$this->assertLessThan(
+			$result->before['total_autoload_size'],
+			$result->after['total_autoload_size']
+		);
+
+		delete_option( 'sr_test_multi_a' );
+		delete_option( 'sr_test_multi_b' );
+	}
+
+	/**
+	 * Test that the fixer is registered in the default plugin fixers.
+	 */
+	public function test_autoload_optimizer_registered_in_plugin() {
+		$plugin   = \SystemReport\Plugin::get_instance();
+		$registry = $plugin->get_fixer_registry();
+
+		$this->assertTrue( $registry->has( 'autoload_optimizer' ) );
+		$this->assertInstanceOf( Autoload_Optimizer::class, $registry->get( 'autoload_optimizer' ) );
+	}
+
+	/**
+	 * Test Risk_Level enum labels.
+	 */
+	public function test_risk_level_labels() {
+		$this->assertNotEmpty( Risk_Level::Low->get_label() );
+		$this->assertNotEmpty( Risk_Level::Medium->get_label() );
+		$this->assertNotEmpty( Risk_Level::High->get_label() );
+	}
+
+	/**
+	 * Test Risk_Level confirmation requirements.
+	 */
+	public function test_risk_level_requires_confirmation() {
+		$this->assertFalse( Risk_Level::Low->requires_confirmation() );
+		$this->assertTrue( Risk_Level::Medium->requires_confirmation() );
+		$this->assertTrue( Risk_Level::High->requires_confirmation() );
+	}
+}


### PR DESCRIPTION
## Summary

- Implements the first concrete fixer: `Autoload_Optimizer` in `includes/fixers/`
- Disables autoload for `wp_options` rows whose serialized values exceed a configurable threshold (default 100 KB)
- Protects ~100 WordPress core options from modification via a hardcoded safelist
- Supports custom thresholds via constructor injection and `wp_system_report_autoload_threshold` filter
- Supports protecting additional options via `wp_system_report_autoload_protected` filter
- Captures before/after snapshots (total autoload size, affected options) in `Fix_Result`
- Registers the fixer in `Plugin::register_default_fixers()` and exposes `Fixer_Registry` via `Plugin::get_fixer_registry()`
- Comprehensive test suite: `Fix_Result` value object, `Fixer_Registry`, `Risk_Level` enum, and `Autoload_Optimizer` functional tests with real database operations

## Test plan

- [ ] PHPCS passes on all PHP versions (8.1–8.4)
- [ ] PHPStan reports no errors
- [ ] PHPUnit passes on all PHP versions (8.1–8.4)
- [ ] Rector dry-run reports no changes
- [ ] Fixer correctly skips core protected options (siteurl, home, etc.)
- [ ] Fixer disables autoload for oversized non-core options
- [ ] Fix_Result snapshots capture meaningful before/after data

## Summary by Sourcery

Introduce an autoload optimization fixer and wire it into the plugin via a shared fixer registry.

New Features:
- Add an Autoload Optimizer fixer that disables autoload for oversized wp_options entries with configurable thresholds and protection mechanisms for critical options.
- Expose a fixer registry from the plugin singleton and register the default Autoload Optimizer fixer under it.

Enhancements:
- Capture structured before/after snapshots, including autoload size and affected options, when applying fixes via Fix_Result value objects.

Tests:
- Add comprehensive unit and functional tests for the fixer registry, Fix_Result, Risk_Level enum, and Autoload Optimizer behavior against a real WordPress options table.