### PR TITLE
Add Database Optimizer fixer (Phase 3.2)

### DIFF
--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -148,6 +148,7 @@ class Plugin {
 	private function register_default_fixers(): void {
 		$fixers = array(
 			new Fixers\Autoload_Optimizer(),
+			new Fixers\Database_Optimizer(),
 		);
 
 		foreach ( $fixers as $fixer ) {

--- a/includes/fixers/class-database-optimizer.php
+++ b/includes/fixers/class-database-optimizer.php
@@ -1,0 +1,307 @@
+<?php
+/**
+ * Database optimizer fixer.
+ *
+ * @package SystemReport
+ */
+
+namespace SystemReport\Fixers;
+
+use SystemReport\Fixer;
+use SystemReport\Fix_Result;
+use SystemReport\Risk_Level;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Optimizes the WordPress database by cleaning expired transients
+ * and reclaiming table overhead (fragmentation).
+ *
+ * Expired transients accumulate in wp_options when they are not
+ * garbage-collected. Database overhead (DATA_FREE) builds up as
+ * rows are inserted, updated, and deleted. This fixer cleans both.
+ */
+class Database_Optimizer implements Fixer {
+
+	/**
+	 * Get the unique slug identifier.
+	 *
+	 * @return string Fixer ID.
+	 */
+	public function get_id(): string {
+		return 'database_optimizer';
+	}
+
+	/**
+	 * Get the human-readable label.
+	 *
+	 * @return string Translated label.
+	 */
+	public function get_label(): string {
+		return __( 'Database Optimizer', 'wp-system-report' );
+	}
+
+	/**
+	 * Get the fixer description.
+	 *
+	 * @return string Translated description.
+	 */
+	public function get_description(): string {
+		return __( 'Cleans expired transients and reclaims table overhead to reduce database bloat.', 'wp-system-report' );
+	}
+
+	/**
+	 * Get the risk level.
+	 *
+	 * @return Risk_Level Risk level.
+	 */
+	public function get_risk_level(): Risk_Level {
+		return Risk_Level::Low;
+	}
+
+	/**
+	 * Get the category.
+	 *
+	 * @return string Category slug.
+	 */
+	public function get_category(): string {
+		return 'database';
+	}
+
+	/**
+	 * Check if any optimization is applicable.
+	 *
+	 * @return bool True when there are expired transients or table overhead.
+	 */
+	public function can_fix(): bool {
+		if ( $this->count_expired_transients() > 0 ) {
+			return true;
+		}
+
+		return $this->get_total_overhead() > 0;
+	}
+
+	/**
+	 * Execute the database optimization.
+	 *
+	 * @return Fix_Result Result with before/after snapshots.
+	 */
+	public function fix(): Fix_Result {
+		$expired_count     = $this->count_expired_transients();
+		$overhead_before   = $this->get_total_overhead();
+		$tables_with_waste = $this->get_tables_with_overhead();
+
+		if ( 0 === $expired_count && 0 === $overhead_before ) {
+			return Fix_Result::success(
+				__( 'Database is already clean. Nothing to optimize.', 'wp-system-report' )
+			);
+		}
+
+		$before = array(
+			'expired_transients' => $expired_count,
+			'total_overhead'     => $overhead_before,
+			'tables_with_waste'  => count( $tables_with_waste ),
+		);
+
+		$errors = array();
+
+		// Step 1: Clean expired transients.
+		$transients_deleted = 0;
+		if ( $expired_count > 0 ) {
+			$transients_deleted = $this->delete_expired_transients();
+		}
+
+		// Step 2: Optimize tables with overhead.
+		$tables_optimized = 0;
+		foreach ( $tables_with_waste as $table_name ) {
+			$result = $this->optimize_table( $table_name );
+			if ( $result ) {
+				++$tables_optimized;
+			} else {
+				$errors[] = sprintf(
+					/* translators: %s: table name */
+					__( 'Failed to optimize table: %s', 'wp-system-report' ),
+					$table_name
+				);
+			}
+		}
+
+		$after = array(
+			'expired_transients' => $this->count_expired_transients(),
+			'total_overhead'     => $this->get_total_overhead(),
+			'transients_deleted' => $transients_deleted,
+			'tables_optimized'   => $tables_optimized,
+		);
+
+		if ( ! empty( $errors ) ) {
+			return Fix_Result::failure(
+				sprintf(
+					/* translators: 1: transients deleted, 2: tables optimized, 3: error count */
+					__( 'Partially completed: %1$d transient(s) deleted, %2$d table(s) optimized, %3$d error(s).', 'wp-system-report' ),
+					$transients_deleted,
+					$tables_optimized,
+					count( $errors )
+				),
+				$errors
+			);
+		}
+
+		$parts = array();
+		if ( $transients_deleted > 0 ) {
+			$parts[] = sprintf(
+				/* translators: %d: number of expired transients deleted */
+				__( '%d expired transient(s) deleted', 'wp-system-report' ),
+				$transients_deleted
+			);
+		}
+		if ( $tables_optimized > 0 ) {
+			$parts[] = sprintf(
+				/* translators: %d: number of tables optimized */
+				__( '%d table(s) optimized', 'wp-system-report' ),
+				$tables_optimized
+			);
+		}
+
+		$message = ! empty( $parts )
+			? implode( ', ', $parts ) . '.'
+			: __( 'Database optimization complete.', 'wp-system-report' );
+
+		return Fix_Result::success( $message, $before, $after );
+	}
+
+	/**
+	 * Count expired transients in the options table.
+	 *
+	 * @return int Number of expired transient timeout rows.
+	 */
+	private function count_expired_transients(): int {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Diagnostic query.
+		return (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$wpdb->options}
+				WHERE option_name LIKE %s
+				AND option_value < %d",
+				$wpdb->esc_like( '_transient_timeout_' ) . '%',
+				time()
+			)
+		);
+	}
+
+	/**
+	 * Delete expired transients and their paired data rows.
+	 *
+	 * @return int Number of transient pairs deleted.
+	 */
+	private function delete_expired_transients(): int {
+		global $wpdb;
+
+		// Find expired timeout keys.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Maintenance operation.
+		$expired = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT option_name FROM {$wpdb->options}
+				WHERE option_name LIKE %s
+				AND option_value < %d
+				LIMIT 1000",
+				$wpdb->esc_like( '_transient_timeout_' ) . '%',
+				time()
+			)
+		);
+
+		if ( empty( $expired ) ) {
+			return 0;
+		}
+
+		$deleted = 0;
+
+		foreach ( $expired as $timeout_key ) {
+			// Each expired timeout has a paired data key.
+			$data_key = str_replace( '_transient_timeout_', '_transient_', $timeout_key );
+
+			delete_option( $data_key );
+			delete_option( $timeout_key );
+			++$deleted;
+		}
+
+		return $deleted;
+	}
+
+	/**
+	 * Get the total overhead (DATA_FREE) across all database tables.
+	 *
+	 * @return int Total overhead in bytes.
+	 */
+	private function get_total_overhead(): int {
+		global $wpdb;
+
+		$database_name = defined( 'DB_NAME' ) ? DB_NAME : '';
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Diagnostic query.
+		$overhead = $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT SUM(DATA_FREE) FROM information_schema.TABLES WHERE TABLE_SCHEMA = %s',
+				$database_name
+			)
+		);
+
+		return (int) $overhead;
+	}
+
+	/**
+	 * Get table names with overhead exceeding the minimum threshold.
+	 *
+	 * Only returns tables within the WordPress prefix to avoid touching
+	 * other applications sharing the same database.
+	 *
+	 * @return string[] Array of table names.
+	 */
+	private function get_tables_with_overhead(): array {
+		global $wpdb;
+
+		$database_name = defined( 'DB_NAME' ) ? DB_NAME : '';
+
+		/**
+		 * Filter the minimum overhead threshold for table optimization.
+		 *
+		 * @param int $threshold Minimum DATA_FREE in bytes. Default 1 MB.
+		 */
+		$threshold = (int) apply_filters( 'wp_system_report_optimize_overhead_threshold', MB_IN_BYTES );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Diagnostic query.
+		$tables = $wpdb->get_col(
+			$wpdb->prepare(
+				'SELECT TABLE_NAME FROM information_schema.TABLES
+				WHERE TABLE_SCHEMA = %s
+				AND TABLE_NAME LIKE %s
+				AND DATA_FREE >= %d',
+				$database_name,
+				$wpdb->esc_like( $wpdb->prefix ) . '%',
+				$threshold
+			)
+		);
+
+		return ! empty( $tables ) ? $tables : array();
+	}
+
+	/**
+	 * Run OPTIMIZE TABLE on a single table.
+	 *
+	 * @param string $table_name Fully qualified table name.
+	 * @return bool True on success.
+	 */
+	private function optimize_table( string $table_name ): bool {
+		global $wpdb;
+
+		// Validate the table name belongs to our prefix.
+		if ( ! str_starts_with( $table_name, $wpdb->prefix ) ) {
+			return false;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name validated against prefix; identifiers cannot use prepare placeholders.
+		$result = $wpdb->query( "OPTIMIZE TABLE `{$table_name}`" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		return false !== $result;
+	}
+}

--- a/tests/FixersTest.php
+++ b/tests/FixersTest.php
@@ -8,6 +8,7 @@
 use SystemReport\Fix_Result;
 use SystemReport\Fixer_Registry;
 use SystemReport\Fixers\Autoload_Optimizer;
+use SystemReport\Fixers\Database_Optimizer;
 use SystemReport\Risk_Level;
 
 /**
@@ -398,5 +399,300 @@ class FixersTest extends WP_UnitTestCase {
 		$this->assertFalse( Risk_Level::Low->requires_confirmation() );
 		$this->assertTrue( Risk_Level::Medium->requires_confirmation() );
 		$this->assertTrue( Risk_Level::High->requires_confirmation() );
+	}
+
+	// -------------------------------------------------------
+	// Database_Optimizer fixer metadata tests.
+	// -------------------------------------------------------
+
+	/**
+	 * Test database optimizer metadata.
+	 */
+	public function test_database_optimizer_metadata() {
+		$fixer = new Database_Optimizer();
+
+		$this->assertSame( 'database_optimizer', $fixer->get_id() );
+		$this->assertNotEmpty( $fixer->get_label() );
+		$this->assertNotEmpty( $fixer->get_description() );
+		$this->assertSame( 'database', $fixer->get_category() );
+		$this->assertSame( Risk_Level::Low, $fixer->get_risk_level() );
+	}
+
+	/**
+	 * Test database optimizer does not require confirmation (Low risk).
+	 */
+	public function test_database_optimizer_low_risk_no_confirmation() {
+		$fixer = new Database_Optimizer();
+		$this->assertFalse( $fixer->get_risk_level()->requires_confirmation() );
+	}
+
+	// -------------------------------------------------------
+	// Database_Optimizer expired transient tests.
+	// -------------------------------------------------------
+
+	/**
+	 * Test can_fix returns false when no expired transients or overhead exist.
+	 */
+	public function test_database_optimizer_can_fix_false_when_clean() {
+		// In a fresh WP test install, there should be no expired transients.
+		// Override the overhead threshold to avoid noise from test DB fragmentation.
+		add_filter( 'wp_system_report_optimize_overhead_threshold', function (): int {
+			return PHP_INT_MAX; // Set impossibly high so overhead check returns nothing.
+		} );
+
+		$fixer = new Database_Optimizer();
+
+		// Delete any expired transients that might exist from other tests.
+		$this->delete_all_expired_transients();
+
+		$this->assertFalse( $fixer->can_fix() );
+
+		remove_all_filters( 'wp_system_report_optimize_overhead_threshold' );
+	}
+
+	/**
+	 * Test can_fix returns true when expired transients exist.
+	 */
+	public function test_database_optimizer_can_fix_true_with_expired_transients() {
+		// Create an expired transient by directly setting a past timestamp.
+		$this->create_expired_transient( 'sr_test_expired', 'test_value', time() - 3600 );
+
+		$fixer = new Database_Optimizer();
+		$this->assertTrue( $fixer->can_fix() );
+
+		$this->cleanup_test_transient( 'sr_test_expired' );
+	}
+
+	/**
+	 * Test fix() deletes expired transients.
+	 */
+	public function test_database_optimizer_fix_deletes_expired_transients() {
+		global $wpdb;
+
+		// Suppress table overhead to isolate transient testing.
+		add_filter( 'wp_system_report_optimize_overhead_threshold', function (): int {
+			return PHP_INT_MAX;
+		} );
+
+		// Create multiple expired transients.
+		$this->create_expired_transient( 'sr_test_exp_a', 'value_a', time() - 7200 );
+		$this->create_expired_transient( 'sr_test_exp_b', 'value_b', time() - 3600 );
+
+		$fixer  = new Database_Optimizer();
+		$result = $fixer->fix();
+
+		$this->assertTrue( $result->success );
+		$this->assertNotEmpty( $result->before );
+		$this->assertNotEmpty( $result->after );
+
+		// Before snapshot should show expired transients.
+		$this->assertGreaterThanOrEqual( 2, $result->before['expired_transients'] );
+
+		// After snapshot should show transients were deleted.
+		$this->assertArrayHasKey( 'transients_deleted', $result->after );
+		$this->assertGreaterThanOrEqual( 2, $result->after['transients_deleted'] );
+
+		// Verify the transient data rows are gone.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Test assertion query.
+		$remaining = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$wpdb->options} WHERE option_name = %s",
+				'_transient_sr_test_exp_a'
+			)
+		);
+		$this->assertSame( '0', $remaining );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Test assertion query.
+		$remaining_timeout = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$wpdb->options} WHERE option_name = %s",
+				'_transient_timeout_sr_test_exp_a'
+			)
+		);
+		$this->assertSame( '0', $remaining_timeout );
+
+		remove_all_filters( 'wp_system_report_optimize_overhead_threshold' );
+		$this->cleanup_test_transient( 'sr_test_exp_a' );
+		$this->cleanup_test_transient( 'sr_test_exp_b' );
+	}
+
+	/**
+	 * Test fix() returns success with nothing to do when database is clean.
+	 */
+	public function test_database_optimizer_fix_noop_when_clean() {
+		// Suppress overhead detection.
+		add_filter( 'wp_system_report_optimize_overhead_threshold', function (): int {
+			return PHP_INT_MAX;
+		} );
+
+		// Ensure no expired transients.
+		$this->delete_all_expired_transients();
+
+		$fixer  = new Database_Optimizer();
+		$result = $fixer->fix();
+
+		$this->assertTrue( $result->success );
+		$this->assertStringContainsString( 'already clean', $result->message );
+
+		remove_all_filters( 'wp_system_report_optimize_overhead_threshold' );
+	}
+
+	/**
+	 * Test fix() success message includes transient count.
+	 */
+	public function test_database_optimizer_fix_message_includes_transient_count() {
+		// Suppress overhead.
+		add_filter( 'wp_system_report_optimize_overhead_threshold', function (): int {
+			return PHP_INT_MAX;
+		} );
+
+		$this->create_expired_transient( 'sr_test_msg', 'val', time() - 100 );
+
+		$fixer  = new Database_Optimizer();
+		$result = $fixer->fix();
+
+		$this->assertTrue( $result->success );
+		$this->assertStringContainsString( 'transient', $result->message );
+
+		remove_all_filters( 'wp_system_report_optimize_overhead_threshold' );
+		$this->cleanup_test_transient( 'sr_test_msg' );
+	}
+
+	/**
+	 * Test the overhead threshold filter.
+	 */
+	public function test_database_optimizer_overhead_threshold_filter() {
+		// Use a filter to set threshold to 0, which should trigger overhead detection
+		// even on small databases.
+		add_filter( 'wp_system_report_optimize_overhead_threshold', function (): int {
+			return 0;
+		} );
+
+		$fixer = new Database_Optimizer();
+
+		// We can't guarantee overhead exists, but the filter should be applied.
+		// Just verify no errors are thrown.
+		$result = $fixer->fix();
+		$this->assertInstanceOf( Fix_Result::class, $result );
+
+		remove_all_filters( 'wp_system_report_optimize_overhead_threshold' );
+	}
+
+	/**
+	 * Test that the database optimizer is registered in the default plugin fixers.
+	 */
+	public function test_database_optimizer_registered_in_plugin() {
+		$plugin   = \SystemReport\Plugin::get_instance();
+		$registry = $plugin->get_fixer_registry();
+
+		$this->assertTrue( $registry->has( 'database_optimizer' ) );
+		$this->assertInstanceOf( Database_Optimizer::class, $registry->get( 'database_optimizer' ) );
+	}
+
+	/**
+	 * Test registry get_by_category includes database optimizer.
+	 */
+	public function test_registry_database_category() {
+		$fixer = new Database_Optimizer();
+		$this->registry->register( $fixer );
+
+		$database = $this->registry->get_by_category( 'database' );
+		$this->assertCount( 1, $database );
+		$this->assertSame( $fixer, $database['database_optimizer'] );
+	}
+
+	/**
+	 * Test registry holds both autoload and database optimizers by category.
+	 */
+	public function test_registry_multiple_categories() {
+		$autoload = new Autoload_Optimizer();
+		$database = new Database_Optimizer();
+
+		$this->registry->register( $autoload );
+		$this->registry->register( $database );
+
+		$performance = $this->registry->get_by_category( 'performance' );
+		$db_category = $this->registry->get_by_category( 'database' );
+
+		$this->assertCount( 1, $performance );
+		$this->assertCount( 1, $db_category );
+		$this->assertSame( $autoload, $performance['autoload_optimizer'] );
+		$this->assertSame( $database, $db_category['database_optimizer'] );
+	}
+
+	// -------------------------------------------------------
+	// Helper methods for transient tests.
+	// -------------------------------------------------------
+
+	/**
+	 * Create an expired transient by directly inserting into the database.
+	 *
+	 * @param string $name      Transient name (without _transient_ prefix).
+	 * @param string $value     Transient value.
+	 * @param int    $timestamp Expiration timestamp (should be in the past).
+	 */
+	private function create_expired_transient( string $name, string $value, int $timestamp ): void {
+		global $wpdb;
+
+		// Insert the data row.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Test setup.
+		$wpdb->replace(
+			$wpdb->options,
+			array(
+				'option_name'  => '_transient_' . $name,
+				'option_value' => $value,
+				'autoload'     => 'no',
+			)
+		);
+
+		// Insert the timeout row with a past timestamp.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Test setup.
+		$wpdb->replace(
+			$wpdb->options,
+			array(
+				'option_name'  => '_transient_timeout_' . $name,
+				'option_value' => (string) $timestamp,
+				'autoload'     => 'no',
+			)
+		);
+
+		// Clear the options cache so our fixer sees the changes.
+		wp_cache_flush();
+	}
+
+	/**
+	 * Clean up a test transient (both data and timeout rows).
+	 *
+	 * @param string $name Transient name (without _transient_ prefix).
+	 */
+	private function cleanup_test_transient( string $name ): void {
+		delete_option( '_transient_' . $name );
+		delete_option( '_transient_timeout_' . $name );
+	}
+
+	/**
+	 * Delete all expired transients for a clean test environment.
+	 */
+	private function delete_all_expired_transients(): void {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Test cleanup.
+		$expired = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT option_name FROM {$wpdb->options}
+				WHERE option_name LIKE %s
+				AND option_value < %d",
+				$wpdb->esc_like( '_transient_timeout_' ) . '%',
+				time()
+			)
+		);
+
+		foreach ( $expired as $timeout_key ) {
+			$data_key = str_replace( '_transient_timeout_', '_transient_', $timeout_key );
+			delete_option( $data_key );
+			delete_option( $timeout_key );
+		}
+
+		wp_cache_flush();
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `Database_Optimizer` fixer that cleans expired transients and reclaims table overhead (DATA_FREE) via `OPTIMIZE TABLE`
- Registers the fixer alongside the existing Autoload Optimizer in `class-plugin.php`
- Comprehensive test coverage in `tests/FixersTest.php` for metadata, transient cleanup, noop scenarios, threshold filter, category grouping, and plugin registration

## Details
- **Expired transient cleanup**: Finds `_transient_timeout_*` rows with past timestamps, deletes both timeout and paired data rows (limit 1000 per execution)
- **Table overhead reclaim**: Queries `information_schema.TABLES` for tables with `DATA_FREE >= threshold` (default 1 MB), runs `OPTIMIZE TABLE` with prefix validation
- **Risk level**: Low (no confirmation required)
- **Filters**: `wp_system_report_optimize_overhead_threshold` to customize the DATA_FREE threshold
- **Before/after snapshots**: Captures expired_transients count, total_overhead, tables_with_waste before and transients_deleted, tables_optimized after

## Test plan
- [ ] PHPCS passes on PHP 8.1–8.4
- [ ] PHPStan passes
- [ ] Rector dry-run is clean
- [ ] PHPUnit passes on PHP 8.1–8.4
- [ ] Database optimizer metadata tests pass (id, label, description, category, risk level)
- [ ] Expired transient tests pass (create expired → can_fix → fix → verify deletion)
- [ ] Noop test passes (clean database → success message with "already clean")
- [ ] Plugin registration test confirms both autoload_optimizer and database_optimizer exist

## Summary by Sourcery

Introduce a low-risk database optimization fixer that cleans expired transients and reclaims WordPress table overhead, and register it with the plugin’s default fixers.

New Features:
- Add a Database_Optimizer fixer that removes expired transients and optimizes WordPress database tables with reclaimable overhead.
- Expose a filter to customize the minimum DATA_FREE threshold for including tables in optimization.

Enhancements:
- Register the database optimizer in the plugin’s fixer registry and ensure it is categorized under the new database category alongside existing performance fixers.

Tests:
- Add comprehensive tests covering database optimizer metadata, expired transient cleanup behavior, no-op scenarios on clean databases, overhead threshold filtering, category-based registry lookups, and plugin registration of both autoload and database optimizers.