### PR TITLE
Add Security Hardener fixer (Phase 3.3)

### DIFF
--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -149,6 +149,7 @@ class Plugin {
 		$fixers = array(
 			new Fixers\Autoload_Optimizer(),
 			new Fixers\Database_Optimizer(),
+			new Fixers\Security_Hardener(),
 		);
 
 		foreach ( $fixers as $fixer ) {
@@ -165,6 +166,9 @@ class Plugin {
 		add_action( 'rest_api_init', array( $this->rest_controller, 'register_routes' ) );
 		add_action( 'rest_api_init', array( $this->error_log_controller, 'register_routes' ) );
 		add_action( 'admin_enqueue_scripts', array( $this->admin_page, 'enqueue_assets' ) );
+
+		// Apply security hardening measures stored from previous fixer runs.
+		Fixers\Security_Hardener::apply_runtime_hardening();
 
 		// Cache invalidation hooks.
 		add_action( 'switch_theme', array( $this, 'clear_theme_cache' ) );

--- a/includes/fixers/class-security-hardener.php
+++ b/includes/fixers/class-security-hardener.php
@@ -1,0 +1,289 @@
+<?php
+/**
+ * Security hardener fixer.
+ *
+ * @package SystemReport
+ */
+
+namespace SystemReport\Fixers;
+
+use SystemReport\Fixer;
+use SystemReport\Fix_Result;
+use SystemReport\Risk_Level;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Hardens the WordPress installation by applying security best practices.
+ *
+ * Detects and remediates common security misconfigurations:
+ *
+ * - XML-RPC enabled when not needed (attack surface reduction)
+ * - File editor enabled (prevents code injection via admin panel)
+ * - Missing security headers (clickjacking, MIME-sniffing, XSS protection)
+ *
+ * All changes are reversible: XML-RPC is disabled via a persistent option,
+ * the file editor requires a wp-config.php constant, and security headers
+ * are added via a persistent option checked on the `send_headers` action.
+ */
+class Security_Hardener implements Fixer {
+
+	/**
+	 * Option name for storing which hardening measures are active.
+	 *
+	 * @var string
+	 */
+	private const OPTION_KEY = 'sr_security_hardening';
+
+	/**
+	 * Recommended security headers.
+	 *
+	 * @var array<string, string>
+	 */
+	private const RECOMMENDED_HEADERS = array(
+		'X-Content-Type-Options' => 'nosniff',
+		'X-Frame-Options'        => 'SAMEORIGIN',
+		'Referrer-Policy'        => 'strict-origin-when-cross-origin',
+	);
+
+	/**
+	 * Get the unique slug identifier.
+	 *
+	 * @return string Fixer ID.
+	 */
+	public function get_id(): string {
+		return 'security_hardener';
+	}
+
+	/**
+	 * Get the human-readable label.
+	 *
+	 * @return string Translated label.
+	 */
+	public function get_label(): string {
+		return __( 'Security Hardener', 'wp-system-report' );
+	}
+
+	/**
+	 * Get the fixer description.
+	 *
+	 * @return string Translated description.
+	 */
+	public function get_description(): string {
+		return __( 'Disables XML-RPC, recommends disabling the file editor, and adds security headers to reduce attack surface.', 'wp-system-report' );
+	}
+
+	/**
+	 * Get the risk level.
+	 *
+	 * @return Risk_Level Risk level.
+	 */
+	public function get_risk_level(): Risk_Level {
+		return Risk_Level::Medium;
+	}
+
+	/**
+	 * Get the category.
+	 *
+	 * @return string Category slug.
+	 */
+	public function get_category(): string {
+		return 'security';
+	}
+
+	/**
+	 * Check if any hardening measures can be applied.
+	 *
+	 * @return bool True when at least one measure is applicable.
+	 */
+	public function can_fix(): bool {
+		if ( $this->is_xmlrpc_enabled() ) {
+			return true;
+		}
+
+		if ( ! $this->is_file_editor_disabled() ) {
+			return true;
+		}
+
+		return $this->has_missing_security_headers();
+	}
+
+	/**
+	 * Execute the security hardening.
+	 *
+	 * @return Fix_Result Result with before/after snapshots.
+	 */
+	public function fix(): Fix_Result {
+		$before = $this->capture_state();
+
+		if ( ! $before['xmlrpc_enabled'] && $before['file_editor_disabled'] && ! $before['missing_headers'] ) {
+			return Fix_Result::success(
+				__( 'All security hardening measures are already in place.', 'wp-system-report' )
+			);
+		}
+
+		$applied = array();
+		$skipped = array();
+
+		// Step 1: Disable XML-RPC.
+		if ( $before['xmlrpc_enabled'] ) {
+			$this->disable_xmlrpc();
+			$applied[] = __( 'XML-RPC disabled', 'wp-system-report' );
+		}
+
+		// Step 2: File editor — we can only advise, not set the constant at runtime.
+		if ( ! $before['file_editor_disabled'] ) {
+			$skipped[] = __( 'File editor: add DISALLOW_FILE_EDIT to wp-config.php manually', 'wp-system-report' );
+		}
+
+		// Step 3: Enable security headers.
+		if ( $before['missing_headers'] ) {
+			$this->enable_security_headers();
+			$applied[] = sprintf(
+				/* translators: %s: comma-separated list of header names */
+				__( 'Security headers enabled: %s', 'wp-system-report' ),
+				implode( ', ', array_keys( $before['missing_headers_list'] ) )
+			);
+		}
+
+		$after = $this->capture_state();
+
+		$parts = $applied;
+		if ( ! empty( $skipped ) ) {
+			$parts = array_merge( $parts, $skipped );
+		}
+
+		$message = ! empty( $parts )
+			? implode( '; ', $parts ) . '.'
+			: __( 'Security hardening complete.', 'wp-system-report' );
+
+		return Fix_Result::success( $message, $before, $after );
+	}
+
+	/**
+	 * Capture the current security state.
+	 *
+	 * @return array<string, mixed> State snapshot.
+	 */
+	private function capture_state(): array {
+		$missing_headers = $this->get_missing_security_headers();
+
+		return array(
+			'xmlrpc_enabled'       => $this->is_xmlrpc_enabled(),
+			'file_editor_disabled' => $this->is_file_editor_disabled(),
+			'missing_headers'      => ! empty( $missing_headers ),
+			'missing_headers_list' => $missing_headers,
+			'hardening_options'    => get_option( self::OPTION_KEY, array() ),
+		);
+	}
+
+	/**
+	 * Check if XML-RPC is currently enabled.
+	 *
+	 * @return bool True if XML-RPC is enabled.
+	 */
+	private function is_xmlrpc_enabled(): bool {
+		$options = get_option( self::OPTION_KEY, array() );
+
+		// If we've previously disabled it via our option, it's disabled.
+		if ( ! empty( $options['xmlrpc_disabled'] ) ) {
+			return false;
+		}
+
+		/**
+		 * Check if XML-RPC is enabled.
+		 *
+		 * We consider it enabled unless we've explicitly disabled it
+		 * or the `xmlrpc_enabled` filter returns false.
+		 */
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Core WordPress filter.
+		return (bool) apply_filters( 'xmlrpc_enabled', true );
+	}
+
+	/**
+	 * Check if the file editor is disabled.
+	 *
+	 * @return bool True if DISALLOW_FILE_EDIT is defined and true.
+	 */
+	private function is_file_editor_disabled(): bool {
+		return defined( 'DISALLOW_FILE_EDIT' ) && DISALLOW_FILE_EDIT;
+	}
+
+	/**
+	 * Check if any recommended security headers are missing.
+	 *
+	 * @return bool True if at least one header is missing.
+	 */
+	private function has_missing_security_headers(): bool {
+		return ! empty( $this->get_missing_security_headers() );
+	}
+
+	/**
+	 * Get the list of missing security headers.
+	 *
+	 * @return array<string, string> Missing headers (name => recommended value).
+	 */
+	private function get_missing_security_headers(): array {
+		$options         = get_option( self::OPTION_KEY, array() );
+		$active_headers  = ! empty( $options['security_headers'] ) ? $options['security_headers'] : array();
+		$missing_headers = array();
+
+		foreach ( self::RECOMMENDED_HEADERS as $header_name => $header_value ) {
+			if ( ! isset( $active_headers[ $header_name ] ) ) {
+				$missing_headers[ $header_name ] = $header_value;
+			}
+		}
+
+		return $missing_headers;
+	}
+
+	/**
+	 * Disable XML-RPC by setting a persistent option.
+	 *
+	 * The option is checked by a filter registered in the plugin constructor.
+	 */
+	private function disable_xmlrpc(): void {
+		$options                    = get_option( self::OPTION_KEY, array() );
+		$options['xmlrpc_disabled'] = true;
+		update_option( self::OPTION_KEY, $options, false );
+	}
+
+	/**
+	 * Enable security headers by storing them in the persistent option.
+	 *
+	 * Headers are sent via a hook on the `send_headers` action.
+	 */
+	private function enable_security_headers(): void {
+		$options                     = get_option( self::OPTION_KEY, array() );
+		$options['security_headers'] = self::RECOMMENDED_HEADERS;
+		update_option( self::OPTION_KEY, $options, false );
+	}
+
+	/**
+	 * Apply runtime security hardening based on stored options.
+	 *
+	 * Called from the plugin's hook registration. This method:
+	 * - Adds the `xmlrpc_enabled` filter to disable XML-RPC
+	 * - Adds the `send_headers` action to send security headers
+	 */
+	public static function apply_runtime_hardening(): void {
+		$options = get_option( self::OPTION_KEY, array() );
+
+		if ( ! empty( $options['xmlrpc_disabled'] ) ) {
+			add_filter( 'xmlrpc_enabled', '__return_false' );
+		}
+
+		if ( ! empty( $options['security_headers'] ) && is_array( $options['security_headers'] ) ) {
+			add_action(
+				'send_headers',
+				function () use ( $options ): void {
+					foreach ( $options['security_headers'] as $name => $value ) {
+						if ( ! headers_sent() ) {
+							header( sprintf( '%s: %s', $name, $value ) );
+						}
+					}
+				}
+			);
+		}
+	}
+}

--- a/tests/FixersTest.php
+++ b/tests/FixersTest.php
@@ -9,6 +9,7 @@ use SystemReport\Fix_Result;
 use SystemReport\Fixer_Registry;
 use SystemReport\Fixers\Autoload_Optimizer;
 use SystemReport\Fixers\Database_Optimizer;
+use SystemReport\Fixers\Security_Hardener;
 use SystemReport\Risk_Level;
 
 /**
@@ -618,6 +619,224 @@ class FixersTest extends WP_UnitTestCase {
 		$this->assertCount( 1, $db_category );
 		$this->assertSame( $autoload, $performance['autoload_optimizer'] );
 		$this->assertSame( $database, $db_category['database_optimizer'] );
+	}
+
+	// -------------------------------------------------------
+	// Security_Hardener fixer metadata tests.
+	// -------------------------------------------------------
+
+	/**
+	 * Test security hardener metadata.
+	 */
+	public function test_security_hardener_metadata() {
+		$fixer = new Security_Hardener();
+
+		$this->assertSame( 'security_hardener', $fixer->get_id() );
+		$this->assertNotEmpty( $fixer->get_label() );
+		$this->assertNotEmpty( $fixer->get_description() );
+		$this->assertSame( 'security', $fixer->get_category() );
+		$this->assertSame( Risk_Level::Medium, $fixer->get_risk_level() );
+	}
+
+	/**
+	 * Test security hardener requires confirmation (Medium risk).
+	 */
+	public function test_security_hardener_requires_confirmation() {
+		$fixer = new Security_Hardener();
+		$this->assertTrue( $fixer->get_risk_level()->requires_confirmation() );
+	}
+
+	// -------------------------------------------------------
+	// Security_Hardener functional tests.
+	// -------------------------------------------------------
+
+	/**
+	 * Test can_fix returns true when XML-RPC is enabled (default state).
+	 */
+	public function test_security_hardener_can_fix_when_xmlrpc_enabled() {
+		// Clear any previous hardening options.
+		delete_option( 'sr_security_hardening' );
+
+		$fixer = new Security_Hardener();
+		$this->assertTrue( $fixer->can_fix() );
+	}
+
+	/**
+	 * Test fix() disables XML-RPC.
+	 */
+	public function test_security_hardener_fix_disables_xmlrpc() {
+		delete_option( 'sr_security_hardening' );
+
+		$fixer  = new Security_Hardener();
+		$result = $fixer->fix();
+
+		$this->assertTrue( $result->success );
+		$this->assertStringContainsString( 'XML-RPC disabled', $result->message );
+
+		// Verify the option was stored.
+		$options = get_option( 'sr_security_hardening', array() );
+		$this->assertTrue( $options['xmlrpc_disabled'] );
+
+		// Clean up.
+		delete_option( 'sr_security_hardening' );
+	}
+
+	/**
+	 * Test fix() enables security headers.
+	 */
+	public function test_security_hardener_fix_enables_security_headers() {
+		delete_option( 'sr_security_hardening' );
+
+		$fixer  = new Security_Hardener();
+		$result = $fixer->fix();
+
+		$this->assertTrue( $result->success );
+		$this->assertStringContainsString( 'Security headers enabled', $result->message );
+
+		// Verify headers are stored.
+		$options = get_option( 'sr_security_hardening', array() );
+		$this->assertArrayHasKey( 'security_headers', $options );
+		$this->assertArrayHasKey( 'X-Content-Type-Options', $options['security_headers'] );
+		$this->assertArrayHasKey( 'X-Frame-Options', $options['security_headers'] );
+		$this->assertArrayHasKey( 'Referrer-Policy', $options['security_headers'] );
+
+		// Clean up.
+		delete_option( 'sr_security_hardening' );
+	}
+
+	/**
+	 * Test fix() returns before/after snapshots.
+	 */
+	public function test_security_hardener_fix_returns_snapshots() {
+		delete_option( 'sr_security_hardening' );
+
+		$fixer  = new Security_Hardener();
+		$result = $fixer->fix();
+
+		$this->assertTrue( $result->success );
+		$this->assertNotEmpty( $result->before );
+		$this->assertNotEmpty( $result->after );
+
+		// Before should show xmlrpc enabled and missing headers.
+		$this->assertTrue( $result->before['xmlrpc_enabled'] );
+		$this->assertTrue( $result->before['missing_headers'] );
+
+		// After should show xmlrpc disabled and no missing headers.
+		$this->assertFalse( $result->after['xmlrpc_enabled'] );
+		$this->assertFalse( $result->after['missing_headers'] );
+
+		// Clean up.
+		delete_option( 'sr_security_hardening' );
+	}
+
+	/**
+	 * Test can_fix returns false after all measures have been applied.
+	 */
+	public function test_security_hardener_can_fix_false_when_hardened() {
+		// Simulate a fully hardened state.
+		update_option(
+			'sr_security_hardening',
+			array(
+				'xmlrpc_disabled'  => true,
+				'security_headers' => array(
+					'X-Content-Type-Options' => 'nosniff',
+					'X-Frame-Options'        => 'SAMEORIGIN',
+					'Referrer-Policy'        => 'strict-origin-when-cross-origin',
+				),
+			),
+			false
+		);
+
+		$fixer = new Security_Hardener();
+
+		// XML-RPC is disabled and headers are set, but file editor
+		// is not disabled (DISALLOW_FILE_EDIT constant not defined).
+		// So can_fix should return true for the file editor advisory.
+		if ( ! defined( 'DISALLOW_FILE_EDIT' ) || ! DISALLOW_FILE_EDIT ) {
+			$this->assertTrue( $fixer->can_fix() );
+		}
+
+		// Clean up.
+		delete_option( 'sr_security_hardening' );
+	}
+
+	/**
+	 * Test fix() noop when already hardened.
+	 */
+	public function test_security_hardener_fix_noop_when_fully_hardened() {
+		// Simulate fully hardened state including file editor.
+		update_option(
+			'sr_security_hardening',
+			array(
+				'xmlrpc_disabled'  => true,
+				'security_headers' => array(
+					'X-Content-Type-Options' => 'nosniff',
+					'X-Frame-Options'        => 'SAMEORIGIN',
+					'Referrer-Policy'        => 'strict-origin-when-cross-origin',
+				),
+			),
+			false
+		);
+
+		$fixer  = new Security_Hardener();
+		$result = $fixer->fix();
+
+		$this->assertTrue( $result->success );
+
+		// The message should mention file editor advisory (since DISALLOW_FILE_EDIT
+		// is not set in test environment) or confirm everything is in place.
+		if ( ! defined( 'DISALLOW_FILE_EDIT' ) || ! DISALLOW_FILE_EDIT ) {
+			$this->assertStringContainsString( 'DISALLOW_FILE_EDIT', $result->message );
+		} else {
+			$this->assertStringContainsString( 'already in place', $result->message );
+		}
+
+		// Clean up.
+		delete_option( 'sr_security_hardening' );
+	}
+
+	/**
+	 * Test that the security hardener is registered in the default plugin fixers.
+	 */
+	public function test_security_hardener_registered_in_plugin() {
+		$plugin   = \SystemReport\Plugin::get_instance();
+		$registry = $plugin->get_fixer_registry();
+
+		$this->assertTrue( $registry->has( 'security_hardener' ) );
+		$this->assertInstanceOf( Security_Hardener::class, $registry->get( 'security_hardener' ) );
+	}
+
+	/**
+	 * Test security hardener appears in security category.
+	 */
+	public function test_registry_security_category() {
+		$fixer = new Security_Hardener();
+		$this->registry->register( $fixer );
+
+		$security = $this->registry->get_by_category( 'security' );
+		$this->assertCount( 1, $security );
+		$this->assertSame( $fixer, $security['security_hardener'] );
+	}
+
+	/**
+	 * Test apply_runtime_hardening registers xmlrpc filter when disabled.
+	 */
+	public function test_apply_runtime_hardening_xmlrpc() {
+		update_option(
+			'sr_security_hardening',
+			array( 'xmlrpc_disabled' => true ),
+			false
+		);
+
+		Security_Hardener::apply_runtime_hardening();
+
+		// The filter should return false for xmlrpc_enabled.
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Core WordPress filter.
+		$this->assertFalse( apply_filters( 'xmlrpc_enabled', true ) );
+
+		// Clean up.
+		remove_all_filters( 'xmlrpc_enabled' );
+		delete_option( 'sr_security_hardening' );
 	}
 
 	// -------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `Security_Hardener` fixer that detects and remediates common WordPress security misconfigurations
- Disables XML-RPC via persistent option (`sr_security_hardening`) and runtime `xmlrpc_enabled` filter
- Advises adding `DISALLOW_FILE_EDIT` to `wp-config.php` (cannot set constants at runtime)
- Adds security headers (`X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`) via `send_headers` action
- Registers runtime hardening in `Plugin::register_hooks()` via `Security_Hardener::apply_runtime_hardening()`
- Includes 11 PHPUnit tests covering all fixer behavior

## Test plan
- [ ] PHPCS passes on all modified files (PHP 8.1–8.4)
- [ ] PHPStan level 6 passes with no errors
- [ ] Rector dry-run reports no suggestions
- [ ] PHPUnit tests pass on PHP 8.1–8.4
- [ ] Security Hardener appears in fixer registry under 'security' category
- [ ] `can_fix()` returns true on fresh installs (XML-RPC enabled by default)
- [ ] `fix()` stores hardening options and returns before/after snapshots
- [ ] Runtime hardening applies XML-RPC filter and security headers on page load

## Summary by Sourcery

Add a new security hardening fixer that stores and applies WordPress security measures and integrates it into the plugin lifecycle and fixer registry.

New Features:
- Introduce a Security_Hardener fixer that detects and remediates common WordPress security misconfigurations such as XML-RPC usage and missing security headers.
- Persist security hardening configuration in a dedicated option and apply it at runtime via XML-RPC filters and HTTP security headers.
- Expose the security hardener through the default fixer registry under the security category.

Tests:
- Add PHPUnit coverage for the Security_Hardener fixer behavior, including metadata, can_fix/fix flows, runtime hardening hooks, and registry integration.