### PR TITLE
Add REST API fixer endpoints (Phase 3.5)

### DIFF
--- a/includes/class-fixer-controller.php
+++ b/includes/class-fixer-controller.php
@@ -1,0 +1,224 @@
+<?php
+/**
+ * Fixer REST API controller.
+ *
+ * @package SystemReport
+ */
+
+namespace SystemReport;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST API controller for listing and executing fixers.
+ *
+ * Provides two endpoints:
+ *
+ * - `GET  /wp-system-report/v1/fixes`           — List all registered fixers with metadata.
+ * - `POST /wp-system-report/v1/fixes/{fix_id}`  — Execute a specific fixer.
+ *
+ * Both endpoints require the `manage_options` capability (filterable via
+ * `wp_system_report_capability`). Executing a fixer returns before/after
+ * state snapshots so callers can verify the outcome.
+ */
+class Fixer_Controller extends \WP_REST_Controller {
+
+	/**
+	 * REST namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wp-system-report/v1';
+
+	/**
+	 * REST route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'fixes';
+
+	/**
+	 * Fixer registry instance.
+	 *
+	 * @var Fixer_Registry
+	 */
+	private Fixer_Registry $registry;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Fixer_Registry $registry Fixer registry instance.
+	 */
+	public function __construct( Fixer_Registry $registry ) {
+		$this->registry = $registry;
+	}
+
+	/**
+	 * Register the REST routes.
+	 */
+	public function register_routes(): void {
+		// GET /fixes — List all available fixers.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'list_fixes' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+					'args'                => array(
+						'category' => array(
+							'description'       => __( 'Filter fixers by category.', 'wp-system-report' ),
+							'type'              => 'string',
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+					),
+				),
+			)
+		);
+
+		// POST /fixes/{fix_id} — Execute a specific fixer.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<fix_id>[a-z0-9_]+)',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'execute_fix' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+					'args'                => array(
+						'fix_id' => array(
+							'description'       => __( 'The fixer identifier.', 'wp-system-report' ),
+							'type'              => 'string',
+							'required'          => true,
+							'sanitize_callback' => 'sanitize_key',
+						),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Check permissions for fixer endpoints.
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 * @return bool|\WP_Error True if permitted, WP_Error otherwise.
+	 */
+	public function permissions_check( $request ) {
+		if ( ! Features::has_fixers() ) {
+			return new \WP_Error(
+				'wp_system_report_fixers_disabled',
+				__( 'Fixer capabilities are not available.', 'wp-system-report' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		/** This filter is documented in includes/class-rest-controller.php. */
+		$capability = apply_filters( 'wp_system_report_capability', 'manage_options' );
+
+		if ( ! is_string( $capability ) || '' === $capability ) {
+			$capability = 'manage_options';
+		}
+
+		if ( ! current_user_can( $capability ) ) {
+			return new \WP_Error(
+				'wp_system_report_rest_forbidden',
+				__( 'Sorry, you are not allowed to manage fixers.', 'wp-system-report' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * List all available fixers.
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 * @return \WP_REST_Response Response with fixer list.
+	 */
+	public function list_fixes( $request ): \WP_REST_Response {
+		$category = $request->get_param( 'category' );
+		$fixers   = $category
+			? $this->registry->get_by_category( $category )
+			: $this->registry->get_all();
+
+		$items = array();
+		foreach ( $fixers as $fixer ) {
+			$items[] = $this->prepare_fixer_item( $fixer );
+		}
+
+		return REST_Envelope::success(
+			$items,
+			array(
+				'total' => count( $items ),
+			)
+		);
+	}
+
+	/**
+	 * Execute a specific fixer.
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 * @return \WP_REST_Response|\WP_Error Response with fix result or error.
+	 */
+	public function execute_fix( $request ) {
+		$fix_id = $request->get_param( 'fix_id' );
+		$fixer  = $this->registry->get( $fix_id );
+
+		if ( null === $fixer ) {
+			return new \WP_Error(
+				'wp_system_report_fixer_not_found',
+				sprintf(
+					/* translators: %s: fixer ID */
+					__( 'Fixer "%s" not found.', 'wp-system-report' ),
+					$fix_id
+				),
+				array( 'status' => 404 )
+			);
+		}
+
+		if ( ! $fixer->can_fix() ) {
+			return REST_Envelope::success(
+				array(
+					'fix_id'  => $fix_id,
+					'result'  => array(
+						'success' => true,
+						'message' => __( 'No issues detected. Nothing to fix.', 'wp-system-report' ),
+					),
+					'applied' => false,
+				)
+			);
+		}
+
+		$result = $fixer->fix();
+
+		return REST_Envelope::success(
+			array(
+				'fix_id'  => $fix_id,
+				'result'  => $result->to_array(),
+				'applied' => true,
+			)
+		);
+	}
+
+	/**
+	 * Prepare a single fixer item for the response.
+	 *
+	 * @param Fixer $fixer Fixer instance.
+	 * @return array<string, mixed> Fixer data for the response.
+	 */
+	private function prepare_fixer_item( Fixer $fixer ): array {
+		return array(
+			'id'                    => $fixer->get_id(),
+			'label'                 => $fixer->get_label(),
+			'description'           => $fixer->get_description(),
+			'category'              => $fixer->get_category(),
+			'risk_level'            => $fixer->get_risk_level()->value,
+			'risk_label'            => $fixer->get_risk_level()->get_label(),
+			'requires_confirmation' => $fixer->get_risk_level()->requires_confirmation(),
+			'can_fix'               => $fixer->can_fix(),
+		);
+	}
+}

--- a/includes/class-fixer-controller.php
+++ b/includes/class-fixer-controller.php
@@ -39,8 +39,6 @@ class Fixer_Controller extends \WP_REST_Controller {
 
 	/**
 	 * Fixer registry instance.
-	 *
-	 * @var Fixer_Registry
 	 */
 	private Fixer_Registry $registry;
 

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -57,6 +57,11 @@ class Plugin {
 	private \SystemReport\Error_Log_Controller $error_log_controller;
 
 	/**
+	 * Fixer controller instance.
+	 */
+	private \SystemReport\Fixer_Controller $fixer_controller;
+
+	/**
 	 * GitHub updater instance.
 	 *
 	 * Stored to prevent garbage collection; hooks are registered in the constructor.
@@ -100,6 +105,7 @@ class Plugin {
 		$this->error_log_reader     = new Error_Log_Reader();
 		$this->debug_toggle         = new Debug_Toggle();
 		$this->error_log_controller = new Error_Log_Controller( $this->error_log_reader, $this->debug_toggle );
+		$this->fixer_controller     = new Fixer_Controller( $this->fixer_registry );
 		$this->github_updater       = new GitHub_Updater( WP_SYSTEM_REPORT_FILE );
 
 		$this->register_default_collectors();
@@ -166,6 +172,7 @@ class Plugin {
 		add_action( 'admin_menu', array( $this->admin_page, 'register_menu' ) );
 		add_action( 'rest_api_init', array( $this->rest_controller, 'register_routes' ) );
 		add_action( 'rest_api_init', array( $this->error_log_controller, 'register_routes' ) );
+		add_action( 'rest_api_init', array( $this->fixer_controller, 'register_routes' ) );
 		add_action( 'admin_enqueue_scripts', array( $this->admin_page, 'enqueue_assets' ) );
 
 		// Apply security hardening measures stored from previous fixer runs.

--- a/tests/FixerControllerTest.php
+++ b/tests/FixerControllerTest.php
@@ -1,0 +1,291 @@
+<?php
+/**
+ * Fixer Controller REST API tests.
+ *
+ * @package SystemReport
+ */
+
+/**
+ * Test the fixer REST API endpoints.
+ */
+class FixerControllerTest extends WP_UnitTestCase {
+
+	/**
+	 * Admin user ID.
+	 *
+	 * @var int
+	 */
+	private int $admin_id;
+
+	/**
+	 * Subscriber user ID.
+	 *
+	 * @var int
+	 */
+	private int $subscriber_id;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->admin_id      = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$this->subscriber_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+
+		// Ensure REST server and routes are initialized.
+		do_action( 'rest_api_init' );
+	}
+
+	// ---------------------------------------------------------------
+	// Route registration
+	// ---------------------------------------------------------------
+
+	/**
+	 * Test that the fixes list route is registered.
+	 */
+	public function test_fixes_list_route_registered(): void {
+		$routes = rest_get_server()->get_routes();
+		$this->assertArrayHasKey( '/wp-system-report/v1/fixes', $routes );
+	}
+
+	/**
+	 * Test that the fix execution route is registered.
+	 */
+	public function test_fix_execution_route_registered(): void {
+		$routes = rest_get_server()->get_routes();
+		$this->assertArrayHasKey( '/wp-system-report/v1/fixes/(?P<fix_id>[a-z0-9_]+)', $routes );
+	}
+
+	// ---------------------------------------------------------------
+	// Permissions
+	// ---------------------------------------------------------------
+
+	/**
+	 * Test that admin can access the fixes list.
+	 */
+	public function test_admin_can_list_fixes(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$request  = new WP_REST_Request( 'GET', '/wp-system-report/v1/fixes' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	/**
+	 * Test that subscriber cannot access the fixes list.
+	 */
+	public function test_subscriber_cannot_list_fixes(): void {
+		wp_set_current_user( $this->subscriber_id );
+
+		$request  = new WP_REST_Request( 'GET', '/wp-system-report/v1/fixes' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	/**
+	 * Test that unauthenticated users cannot access fixes.
+	 */
+	public function test_unauthenticated_cannot_list_fixes(): void {
+		wp_set_current_user( 0 );
+
+		$request  = new WP_REST_Request( 'GET', '/wp-system-report/v1/fixes' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 401, $response->get_status() );
+	}
+
+	/**
+	 * Test that subscriber cannot execute a fix.
+	 */
+	public function test_subscriber_cannot_execute_fix(): void {
+		wp_set_current_user( $this->subscriber_id );
+
+		$request  = new WP_REST_Request( 'POST', '/wp-system-report/v1/fixes/autoload_optimizer' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	// ---------------------------------------------------------------
+	// List fixes
+	// ---------------------------------------------------------------
+
+	/**
+	 * Test list fixes returns the standard envelope.
+	 */
+	public function test_list_fixes_returns_envelope(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$request  = new WP_REST_Request( 'GET', '/wp-system-report/v1/fixes' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertArrayHasKey( 'status', $data );
+		$this->assertSame( 'success', $data['status'] );
+		$this->assertArrayHasKey( 'data', $data );
+		$this->assertArrayHasKey( 'meta', $data );
+		$this->assertArrayHasKey( 'total', $data['meta'] );
+	}
+
+	/**
+	 * Test list fixes includes all registered fixers.
+	 */
+	public function test_list_fixes_includes_all_fixers(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$request  = new WP_REST_Request( 'GET', '/wp-system-report/v1/fixes' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$ids = array_column( $data['data'], 'id' );
+
+		$this->assertContains( 'autoload_optimizer', $ids );
+		$this->assertContains( 'database_optimizer', $ids );
+		$this->assertContains( 'security_hardener', $ids );
+		$this->assertContains( 'cron_repair', $ids );
+	}
+
+	/**
+	 * Test list fixes returns correct structure per fixer.
+	 */
+	public function test_list_fixes_item_structure(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$request  = new WP_REST_Request( 'GET', '/wp-system-report/v1/fixes' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$first_item = $data['data'][0];
+
+		$this->assertArrayHasKey( 'id', $first_item );
+		$this->assertArrayHasKey( 'label', $first_item );
+		$this->assertArrayHasKey( 'description', $first_item );
+		$this->assertArrayHasKey( 'category', $first_item );
+		$this->assertArrayHasKey( 'risk_level', $first_item );
+		$this->assertArrayHasKey( 'risk_label', $first_item );
+		$this->assertArrayHasKey( 'requires_confirmation', $first_item );
+		$this->assertArrayHasKey( 'can_fix', $first_item );
+	}
+
+	/**
+	 * Test list fixes with category filter.
+	 */
+	public function test_list_fixes_category_filter(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$request = new WP_REST_Request( 'GET', '/wp-system-report/v1/fixes' );
+		$request->set_param( 'category', 'security' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$categories = array_unique( array_column( $data['data'], 'category' ) );
+
+		$this->assertCount( 1, $categories );
+		$this->assertSame( 'security', $categories[0] );
+	}
+
+	/**
+	 * Test list fixes with nonexistent category returns empty.
+	 */
+	public function test_list_fixes_empty_category(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$request = new WP_REST_Request( 'GET', '/wp-system-report/v1/fixes' );
+		$request->set_param( 'category', 'nonexistent_category' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEmpty( $data['data'] );
+		$this->assertSame( 0, $data['meta']['total'] );
+	}
+
+	// ---------------------------------------------------------------
+	// Execute fix
+	// ---------------------------------------------------------------
+
+	/**
+	 * Test executing a nonexistent fixer returns 404.
+	 */
+	public function test_execute_nonexistent_fixer_returns_404(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$request  = new WP_REST_Request( 'POST', '/wp-system-report/v1/fixes/nonexistent_fixer' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 404, $response->get_status() );
+	}
+
+	/**
+	 * Test executing a fixer returns success envelope.
+	 */
+	public function test_execute_fixer_returns_envelope(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$request  = new WP_REST_Request( 'POST', '/wp-system-report/v1/fixes/security_hardener' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertArrayHasKey( 'status', $data );
+		$this->assertSame( 'success', $data['status'] );
+		$this->assertArrayHasKey( 'data', $data );
+		$this->assertArrayHasKey( 'fix_id', $data['data'] );
+		$this->assertArrayHasKey( 'result', $data['data'] );
+		$this->assertArrayHasKey( 'applied', $data['data'] );
+	}
+
+	/**
+	 * Test executing a fixer includes result details.
+	 */
+	public function test_execute_fixer_result_structure(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$request  = new WP_REST_Request( 'POST', '/wp-system-report/v1/fixes/security_hardener' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$result = $data['data']['result'];
+
+		$this->assertArrayHasKey( 'success', $result );
+		$this->assertArrayHasKey( 'message', $result );
+		$this->assertTrue( $result['success'] );
+	}
+
+	/**
+	 * Test that the feature gate blocks access when Pro is disabled.
+	 */
+	public function test_feature_gate_blocks_when_disabled(): void {
+		wp_set_current_user( $this->admin_id );
+
+		add_filter( 'wp_system_report_is_pro', '__return_false' );
+
+		$request  = new WP_REST_Request( 'GET', '/wp-system-report/v1/fixes' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 403, $response->get_status() );
+
+		remove_filter( 'wp_system_report_is_pro', '__return_false' );
+	}
+
+	/**
+	 * Test execute fix with a fixer that has nothing to fix returns not-applied.
+	 */
+	public function test_execute_fixer_nothing_to_fix(): void {
+		wp_set_current_user( $this->admin_id );
+
+		// Run the security hardener first to clear issues.
+		$request = new WP_REST_Request( 'POST', '/wp-system-report/v1/fixes/security_hardener' );
+		rest_get_server()->dispatch( $request );
+
+		// Run it again — should say nothing to fix.
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		// Either applied=false (can_fix returned false) or the fixer returned a noop success.
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertTrue( $data['data']['result']['success'] );
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `Fixer_Controller` REST controller with two endpoints:
  - `GET /wp-system-report/v1/fixes` — list all registered fixers with metadata (id, label, description, category, risk_level, can_fix). Supports `?category=` filtering.
  - `POST /wp-system-report/v1/fixes/{fix_id}` — execute a specific fixer, returning before/after snapshots in the standard `REST_Envelope` format.
- Both endpoints are feature-gated via `Features::has_fixers()` and require `manage_options` capability (filterable via `wp_system_report_capability`).
- Wires `Fixer_Controller` into the `Plugin` orchestrator alongside existing REST and Error Log controllers.

## Test plan
- [ ] PHPCS passes on PHP 8.1–8.4
- [ ] PHPStan passes with no errors
- [ ] Rector dry-run shows no suggestions
- [ ] 14 new tests in `FixerControllerTest` pass:
  - Route registration (GET and POST)
  - Admin can list fixes, subscriber/unauthenticated cannot
  - Envelope structure validation
  - All 4 fixers included in listing
  - Item structure (id, label, description, category, risk_level, risk_label, requires_confirmation, can_fix)
  - Category filtering works, empty category returns empty
  - Nonexistent fixer returns 404
  - Execute returns envelope with fix_id, result, applied
  - Feature gate blocks when disabled
  - Idempotent execution (nothing-to-fix case)

## Summary by Sourcery

Introduce a REST API controller for listing and executing registered fixers and wire it into the plugin’s REST bootstrapping.

New Features:
- Expose a GET /wp-system-report/v1/fixes endpoint to list registered fixers with metadata and optional category filtering.
- Expose a POST /wp-system-report/v1/fixes/{fix_id} endpoint to execute a specific fixer and return a standardized envelope with execution results.

Enhancements:
- Gate fixer REST endpoints behind the existing feature flag and a filterable capability check for administrative access.
- Integrate the fixer controller into the main plugin orchestrator so its routes are registered with the REST API on init.

Tests:
- Add a comprehensive FixerControllerTest suite covering route registration, permissions, response envelopes, listing behavior, category filtering, feature gating, fixer execution semantics, and idempotent runs.