### PR TITLE
Add health score calculator (Phase 5.6)

### DIFF
--- a/includes/class-features.php
+++ b/includes/class-features.php
@@ -66,6 +66,18 @@ class Features {
 	}
 
 	/**
+	 * Whether the health score feature is available.
+	 *
+	 * Health score aggregates all collector results into a single
+	 * 0–100 score with a letter grade. Gated behind the Pro tier.
+	 *
+	 * @return bool True when health score is available.
+	 */
+	public static function has_health_score(): bool {
+		return self::is_pro();
+	}
+
+	/**
 	 * Whether Abilities API integration is available.
 	 *
 	 * Abilities API integration exposes plugin capabilities as structured

--- a/includes/class-health-score-controller.php
+++ b/includes/class-health-score-controller.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Health score REST controller.
+ *
+ * @package SystemReport
+ */
+
+namespace SystemReport;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST API controller for the health score endpoint.
+ *
+ * Provides:
+ * - GET /wp-system-report/v1/health-score — full score with breakdown.
+ */
+class Health_Score_Controller extends \WP_REST_Controller {
+
+	/**
+	 * REST namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wp-system-report/v1';
+
+	/**
+	 * REST route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'health-score';
+
+	/**
+	 * Health score calculator instance.
+	 *
+	 * @var Health_Score
+	 */
+	private Health_Score $health_score;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Health_Score $health_score Health score calculator instance.
+	 */
+	public function __construct( Health_Score $health_score ) {
+		$this->health_score = $health_score;
+	}
+
+	/**
+	 * Register the REST routes.
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_health_score' ),
+					'permission_callback' => array( $this, 'get_health_score_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Check permissions for viewing the health score.
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 * @return bool|\WP_Error True if permitted, WP_Error otherwise.
+	 */
+	public function get_health_score_permissions_check( $request ) {
+		/** This filter is documented in includes/class-rest-controller.php */
+		$capability = apply_filters( 'wp_system_report_capability', 'manage_options' );
+
+		if ( ! is_string( $capability ) || '' === $capability ) {
+			$capability = 'manage_options';
+		}
+
+		if ( ! current_user_can( $capability ) ) {
+			return new \WP_Error(
+				'wp_system_report_rest_forbidden',
+				__( 'Sorry, you are not allowed to view the health score.', 'wp-system-report' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get the health score.
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 * @return \WP_REST_Response Health score response.
+	 */
+	public function get_health_score( $request ): \WP_REST_Response {
+		$result = $this->health_score->calculate();
+
+		return REST_Envelope::success(
+			$result,
+			array( 'endpoint' => 'health-score' )
+		);
+	}
+
+	/**
+	 * Get the schema for the health score endpoint.
+	 *
+	 * @return array JSON Schema for the endpoint.
+	 */
+	public function get_public_item_schema(): array {
+		return array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'health-score',
+			'type'       => 'object',
+			'properties' => array(
+				'score'     => array(
+					'description' => __( 'Aggregate health score (0-100).', 'wp-system-report' ),
+					'type'        => 'integer',
+					'minimum'     => 0,
+					'maximum'     => 100,
+				),
+				'grade'     => array(
+					'description' => __( 'Letter grade derived from the score.', 'wp-system-report' ),
+					'type'        => 'string',
+					'enum'        => array( 'A+', 'A', 'B', 'C', 'D', 'F' ),
+				),
+				'breakdown' => array(
+					'description' => __( 'Per-section score breakdown.', 'wp-system-report' ),
+					'type'        => 'object',
+				),
+				'summary'   => array(
+					'description' => __( 'Overall field status summary.', 'wp-system-report' ),
+					'type'        => 'object',
+					'properties'  => array(
+						'total_fields' => array( 'type' => 'integer' ),
+						'good'         => array( 'type' => 'integer' ),
+						'warnings'     => array( 'type' => 'integer' ),
+						'criticals'    => array( 'type' => 'integer' ),
+						'info'         => array( 'type' => 'integer' ),
+					),
+				),
+			),
+		);
+	}
+}

--- a/includes/class-health-score-controller.php
+++ b/includes/class-health-score-controller.php
@@ -33,8 +33,6 @@ class Health_Score_Controller extends \WP_REST_Controller {
 
 	/**
 	 * Health score calculator instance.
-	 *
-	 * @var Health_Score
 	 */
 	private Health_Score $health_score;
 

--- a/includes/class-health-score.php
+++ b/includes/class-health-score.php
@@ -1,0 +1,304 @@
+<?php
+/**
+ * Health score calculator.
+ *
+ * @package SystemReport
+ */
+
+namespace SystemReport;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Computes an aggregate health score (0–100) from report data.
+ *
+ * The score is weighted by collector category importance:
+ *
+ * - Critical categories (security, performance, updates) carry more weight.
+ * - Each field contributes based on its status: Good = 100, Warning = 40, Critical = 0, Info = neutral.
+ * - Info fields are excluded from scoring as they are purely informational.
+ *
+ * The final score is a weighted average across all scored categories.
+ */
+class Health_Score {
+
+	/**
+	 * Category weights for scoring.
+	 *
+	 * Higher weight = more impact on the final score.
+	 * Collectors not listed here receive the default weight.
+	 *
+	 * @var array<string, float>
+	 */
+	private const CATEGORY_WEIGHTS = array(
+		'security'                => 3.0,
+		'update_health'           => 2.5,
+		'performance'             => 2.5,
+		'wordpress_environment'   => 2.0,
+		'server_environment'      => 2.0,
+		'database'                => 2.0,
+		'cron_health'             => 1.5,
+		'email_delivery'          => 1.5,
+		'network_connectivity'    => 1.5,
+		'filesystem_permissions'  => 1.5,
+		'site_health'             => 1.5,
+		'active_plugins'          => 1.0,
+		'inactive_plugins'        => 0.5,
+		'theme_info'              => 1.0,
+		'media_uploads'           => 1.0,
+		'block_editor'            => 0.5,
+		'rest_api_info'           => 1.0,
+		'wordpress_constants'     => 0.5,
+		'wordpress_configuration' => 0.5,
+		'post_type_counts'        => 0.25,
+		'custom_content_types'    => 0.25,
+		'dropins_mu_plugins'      => 0.5,
+		'advanced_diagnostics'    => 1.0,
+	);
+
+	/**
+	 * Default weight for collectors not in CATEGORY_WEIGHTS.
+	 *
+	 * @var float
+	 */
+	private const DEFAULT_WEIGHT = 1.0;
+
+	/**
+	 * Points awarded per status.
+	 *
+	 * @var array<string, int>
+	 */
+	private const STATUS_POINTS = array(
+		'good'     => 100,
+		'warning'  => 40,
+		'critical' => 0,
+	);
+
+	/**
+	 * Report generator instance.
+	 *
+	 * @var Report_Generator
+	 */
+	private Report_Generator $report_generator;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Report_Generator $report_generator Report generator instance.
+	 */
+	public function __construct( Report_Generator $report_generator ) {
+		$this->report_generator = $report_generator;
+	}
+
+	/**
+	 * Calculate the health score from the full report.
+	 *
+	 * @param array|null $report Optional pre-generated report data. If null, generates fresh.
+	 * @return array{
+	 *     score: int,
+	 *     grade: string,
+	 *     breakdown: array<string, array{score: int, weight: float, label: string, field_count: int, warnings: int, criticals: int}>,
+	 *     summary: array{total_fields: int, good: int, warnings: int, criticals: int, info: int}
+	 * }
+	 */
+	public function calculate( ?array $report = null ): array {
+		if ( null === $report ) {
+			$report = $this->report_generator->generate();
+		}
+
+		$breakdown    = array();
+		$total_weight = 0.0;
+		$weighted_sum = 0.0;
+
+		// Summary counters.
+		$summary = array(
+			'total_fields' => 0,
+			'good'         => 0,
+			'warnings'     => 0,
+			'criticals'    => 0,
+			'info'         => 0,
+		);
+
+		foreach ( $report as $section_id => $section ) {
+			$fields = $section['fields'] ?? array();
+
+			if ( empty( $fields ) ) {
+				continue;
+			}
+
+			$section_result = $this->score_section( $section_id, $fields );
+
+			// Update summary counters.
+			$summary['total_fields'] += $section_result['field_count'];
+			$summary['good']         += $section_result['good'];
+			$summary['warnings']     += $section_result['warnings'];
+			$summary['criticals']    += $section_result['criticals'];
+			$summary['info']         += $section_result['info'];
+
+			// Only include sections with scored (non-info) fields.
+			if ( $section_result['scored_count'] > 0 ) {
+				$weight        = $this->get_weight( $section_id );
+				$total_weight += $weight;
+				$weighted_sum += $section_result['score'] * $weight;
+
+				$breakdown[ $section_id ] = array(
+					'score'       => $section_result['score'],
+					'weight'      => $weight,
+					'label'       => $section['label'] ?? $section_id,
+					'field_count' => $section_result['field_count'],
+					'warnings'    => $section_result['warnings'],
+					'criticals'   => $section_result['criticals'],
+				);
+			}
+		}
+
+		$score = $total_weight > 0
+			? (int) round( $weighted_sum / $total_weight )
+			: 100;
+
+		// Clamp to 0-100.
+		$score = max( 0, min( 100, $score ) );
+
+		/**
+		 * Filter the computed health score.
+		 *
+		 * @param int   $score     The health score (0-100).
+		 * @param array $breakdown Per-section score breakdown.
+		 * @param array $report    The raw report data.
+		 */
+		$score = (int) apply_filters( 'wp_system_report_health_score', $score, $breakdown, $report );
+
+		return array(
+			'score'     => $score,
+			'grade'     => self::score_to_grade( $score ),
+			'breakdown' => $breakdown,
+			'summary'   => $summary,
+		);
+	}
+
+	/**
+	 * Score a single report section.
+	 *
+	 * @param string $section_id The collector ID.
+	 * @param array  $fields     Array of Field objects or arrays.
+	 * @return array{score: int, field_count: int, scored_count: int, good: int, warnings: int, criticals: int, info: int}
+	 */
+	private function score_section( string $section_id, array $fields ): array {
+		$total_points = 0;
+		$scored_count = 0;
+		$good         = 0;
+		$warnings     = 0;
+		$criticals    = 0;
+		$info         = 0;
+		$field_count  = count( $fields );
+
+		foreach ( $fields as $field ) {
+			$status = $this->get_field_status( $field );
+
+			if ( 'info' === $status ) {
+				++$info;
+				continue;
+			}
+
+			$points        = self::STATUS_POINTS[ $status ] ?? 100;
+			$total_points += $points;
+			++$scored_count;
+
+			switch ( $status ) {
+				case 'good':
+					++$good;
+					break;
+				case 'warning':
+					++$warnings;
+					break;
+				case 'critical':
+					++$criticals;
+					break;
+			}
+		}
+
+		$score = $scored_count > 0
+			? (int) round( $total_points / $scored_count )
+			: 100;
+
+		return array(
+			'score'        => $score,
+			'field_count'  => $field_count,
+			'scored_count' => $scored_count,
+			'good'         => $good,
+			'warnings'     => $warnings,
+			'criticals'    => $criticals,
+			'info'         => $info,
+		);
+	}
+
+	/**
+	 * Get the status string from a field.
+	 *
+	 * Supports both Field objects and legacy associative arrays.
+	 *
+	 * @param Field|array $field A field value object or associative array.
+	 * @return string Status string: 'good', 'warning', 'critical', or 'info'.
+	 */
+	private function get_field_status( $field ): string {
+		if ( $field instanceof Field ) {
+			return $field->status->value;
+		}
+
+		if ( is_array( $field ) && isset( $field['status'] ) ) {
+			$status = $field['status'];
+
+			if ( $status instanceof Status ) {
+				return $status->value;
+			}
+
+			return is_string( $status ) ? $status : 'info';
+		}
+
+		return 'info';
+	}
+
+	/**
+	 * Get the weight for a collector section.
+	 *
+	 * @param string $section_id The collector ID.
+	 * @return float Weight multiplier.
+	 */
+	private function get_weight( string $section_id ): float {
+		$weights = self::CATEGORY_WEIGHTS;
+
+		/**
+		 * Filter the category weights for health score calculation.
+		 *
+		 * @param array<string, float> $weights Map of section ID to weight.
+		 */
+		$weights = apply_filters( 'wp_system_report_health_score_weights', $weights );
+
+		return $weights[ $section_id ] ?? self::DEFAULT_WEIGHT;
+	}
+
+	/**
+	 * Convert a numeric score to a letter grade.
+	 *
+	 * @param int $score The health score (0-100).
+	 * @return string Letter grade: A+, A, B, C, D, or F.
+	 */
+	public static function score_to_grade( int $score ): string {
+		if ( $score >= 95 ) {
+			return 'A+';
+		}
+		if ( $score >= 80 ) {
+			return 'A';
+		}
+		if ( $score >= 65 ) {
+			return 'B';
+		}
+		if ( $score >= 50 ) {
+			return 'C';
+		}
+		if ( $score >= 35 ) {
+			return 'D';
+		}
+		return 'F';
+	}
+}

--- a/includes/class-health-score.php
+++ b/includes/class-health-score.php
@@ -104,6 +104,16 @@ class Health_Score {
 			$report = $this->report_generator->generate();
 		}
 
+		/**
+		 * Filter the category weights for health score calculation.
+		 *
+		 * Filtered once here so that the filter callback is not invoked on
+		 * every individual section lookup inside the loop.
+		 *
+		 * @param array<string, float> $weights Map of section ID to weight.
+		 */
+		$weights = (array) apply_filters( 'wp_system_report_health_score_weights', self::CATEGORY_WEIGHTS );
+
 		$breakdown    = array();
 		$total_weight = 0.0;
 		$weighted_sum = 0.0;
@@ -135,7 +145,7 @@ class Health_Score {
 
 			// Only include sections with scored (non-info) fields.
 			if ( $section_result['scored_count'] > 0 ) {
-				$weight        = $this->get_weight( $section_id );
+				$weight        = $this->get_weight( $section_id, $weights );
 				$total_weight += $weight;
 				$weighted_sum += $section_result['score'] * $weight;
 
@@ -154,7 +164,7 @@ class Health_Score {
 			? (int) round( $weighted_sum / $total_weight )
 			: 100;
 
-		// Clamp to 0-100.
+		// Clamp to 0-100 before passing to the filter.
 		$score = max( 0, min( 100, $score ) );
 
 		/**
@@ -165,6 +175,9 @@ class Health_Score {
 		 * @param array $report    The raw report data.
 		 */
 		$score = (int) apply_filters( 'wp_system_report_health_score', $score, $breakdown, $report );
+
+		// Clamp again after the filter to prevent out-of-range values from filter callbacks.
+		$score = max( 0, min( 100, $score ) );
 
 		return array(
 			'score'     => $score,
@@ -198,7 +211,15 @@ class Health_Score {
 				continue;
 			}
 
-			$points        = self::STATUS_POINTS[ $status ] ?? 100;
+			$points = self::STATUS_POINTS[ $status ] ?? null;
+
+			// Unknown statuses are treated as non-scoring (like 'info') to prevent
+			// typos or unrecognised status values from artificially inflating the score.
+			if ( null === $points ) {
+				++$info;
+				continue;
+			}
+
 			$total_points += $points;
 			++$scored_count;
 
@@ -259,19 +280,15 @@ class Health_Score {
 	/**
 	 * Get the weight for a collector section.
 	 *
-	 * @param string $section_id The collector ID.
+	 * Accepts the pre-filtered weights array so that the
+	 * 'wp_system_report_health_score_weights' filter is only applied once
+	 * per calculate() call rather than on every section lookup.
+	 *
+	 * @param string               $section_id The collector ID.
+	 * @param array<string, float> $weights    Pre-filtered map of section ID to weight.
 	 * @return float Weight multiplier.
 	 */
-	private function get_weight( string $section_id ): float {
-		$weights = self::CATEGORY_WEIGHTS;
-
-		/**
-		 * Filter the category weights for health score calculation.
-		 *
-		 * @param array<string, float> $weights Map of section ID to weight.
-		 */
-		$weights = apply_filters( 'wp_system_report_health_score_weights', $weights );
-
+	private function get_weight( string $section_id, array $weights ): float {
 		return $weights[ $section_id ] ?? self::DEFAULT_WEIGHT;
 	}
 

--- a/includes/class-health-score.php
+++ b/includes/class-health-score.php
@@ -76,8 +76,6 @@ class Health_Score {
 
 	/**
 	 * Report generator instance.
-	 *
-	 * @var Report_Generator
 	 */
 	private Report_Generator $report_generator;
 

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -67,6 +67,16 @@ class Plugin {
 	private \SystemReport\AI_Context_Generator $ai_context_generator;
 
 	/**
+	 * Health score calculator instance.
+	 */
+	private \SystemReport\Health_Score $health_score;
+
+	/**
+	 * Health score controller instance.
+	 */
+	private \SystemReport\Health_Score_Controller $health_score_controller;
+
+	/**
 	 * Notification manager instance.
 	 */
 	private \SystemReport\Notification_Manager $notification_manager;
@@ -128,6 +138,8 @@ class Plugin {
 		$this->debug_toggle            = new Debug_Toggle();
 		$this->error_log_controller    = new Error_Log_Controller( $this->error_log_reader, $this->debug_toggle );
 		$this->fixer_controller        = new Fixer_Controller( $this->fixer_registry );
+		$this->health_score            = new Health_Score( $this->report_generator );
+		$this->health_score_controller = new Health_Score_Controller( $this->health_score );
 		$this->ai_context_generator    = new AI_Context_Generator( $this->report_generator );
 		$webhook_dispatcher            = new Webhook_Dispatcher();
 		$this->notification_manager    = new Notification_Manager( $webhook_dispatcher );
@@ -203,6 +215,7 @@ class Plugin {
 		add_action( 'rest_api_init', array( $this->error_log_controller, 'register_routes' ) );
 		add_action( 'rest_api_init', array( $this->fixer_controller, 'register_routes' ) );
 		add_action( 'rest_api_init', array( $this->notification_controller, 'register_routes' ) );
+		add_action( 'rest_api_init', array( $this->health_score_controller, 'register_routes' ) );
 		add_action( 'admin_enqueue_scripts', array( $this->admin_page, 'enqueue_assets' ) );
 
 		// Apply security hardening measures stored from previous fixer runs.
@@ -250,6 +263,15 @@ class Plugin {
 	 */
 	public function get_fixer_registry(): Fixer_Registry {
 		return $this->fixer_registry;
+	}
+
+	/**
+	 * Get the health score calculator.
+	 *
+	 * @return Health_Score The health score calculator instance.
+	 */
+	public function get_health_score(): Health_Score {
+		return $this->health_score;
 	}
 
 	/**

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -73,8 +73,10 @@ class Plugin {
 
 	/**
 	 * Health score controller instance.
+	 *
+	 * Null when the health score feature flag is disabled.
 	 */
-	private \SystemReport\Health_Score_Controller $health_score_controller;
+	private ?\SystemReport\Health_Score_Controller $health_score_controller = null;
 
 	/**
 	 * Notification manager instance.
@@ -130,16 +132,20 @@ class Plugin {
 	 * Constructor.
 	 */
 	private function __construct() {
-		$this->report_generator        = new Report_Generator();
-		$this->fixer_registry          = new Fixer_Registry();
-		$this->admin_page              = new Admin_Page( $this->report_generator );
-		$this->rest_controller         = new REST_Controller( $this->report_generator );
-		$this->error_log_reader        = new Error_Log_Reader();
-		$this->debug_toggle            = new Debug_Toggle();
-		$this->error_log_controller    = new Error_Log_Controller( $this->error_log_reader, $this->debug_toggle );
-		$this->fixer_controller        = new Fixer_Controller( $this->fixer_registry );
-		$this->health_score            = new Health_Score( $this->report_generator );
-		$this->health_score_controller = new Health_Score_Controller( $this->health_score );
+		$this->report_generator     = new Report_Generator();
+		$this->fixer_registry       = new Fixer_Registry();
+		$this->admin_page           = new Admin_Page( $this->report_generator );
+		$this->rest_controller      = new REST_Controller( $this->report_generator );
+		$this->error_log_reader     = new Error_Log_Reader();
+		$this->debug_toggle         = new Debug_Toggle();
+		$this->error_log_controller = new Error_Log_Controller( $this->error_log_reader, $this->debug_toggle );
+		$this->fixer_controller     = new Fixer_Controller( $this->fixer_registry );
+		$this->health_score         = new Health_Score( $this->report_generator );
+
+		if ( Features::has_health_score() ) {
+			$this->health_score_controller = new Health_Score_Controller( $this->health_score );
+		}
+
 		$this->ai_context_generator    = new AI_Context_Generator( $this->report_generator );
 		$webhook_dispatcher            = new Webhook_Dispatcher();
 		$this->notification_manager    = new Notification_Manager( $webhook_dispatcher );
@@ -215,7 +221,10 @@ class Plugin {
 		add_action( 'rest_api_init', array( $this->error_log_controller, 'register_routes' ) );
 		add_action( 'rest_api_init', array( $this->fixer_controller, 'register_routes' ) );
 		add_action( 'rest_api_init', array( $this->notification_controller, 'register_routes' ) );
-		add_action( 'rest_api_init', array( $this->health_score_controller, 'register_routes' ) );
+
+		if ( null !== $this->health_score_controller ) {
+			add_action( 'rest_api_init', array( $this->health_score_controller, 'register_routes' ) );
+		}
 		add_action( 'admin_enqueue_scripts', array( $this->admin_page, 'enqueue_assets' ) );
 
 		// Apply security hardening measures stored from previous fixer runs.

--- a/tests/HealthScoreTest.php
+++ b/tests/HealthScoreTest.php
@@ -255,6 +255,31 @@ class HealthScoreTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that unknown status values are treated as non-scoring (like info).
+	 *
+	 * An unrecognised status should not inflate the score by defaulting to 100 pts.
+	 */
+	public function test_unknown_status_treated_as_non_scoring(): void {
+		$report = $this->build_report( array(
+			'security' => array(
+				$this->make_field( 'Good', 'OK', Status::Good ),
+				// Inject a raw-array field with an unrecognised status string.
+				array(
+					'label'  => 'Unknown',
+					'value'  => 'mystery',
+					'status' => 'future_status',
+				),
+			),
+		) );
+
+		$result = $this->health_score->calculate( $report );
+
+		// Only the Good field scores; unknown is treated as info.
+		$this->assertSame( 100, $result['score'] );
+		$this->assertSame( 1, $result['summary']['info'] );
+	}
+
+	/**
 	 * Test that sections with only info fields are excluded from breakdown.
 	 */
 	public function test_info_only_sections_excluded_from_breakdown(): void {

--- a/tests/HealthScoreTest.php
+++ b/tests/HealthScoreTest.php
@@ -1,0 +1,312 @@
+<?php
+/**
+ * Health Score tests.
+ *
+ * @package SystemReport
+ */
+
+use SystemReport\Health_Score;
+use SystemReport\Report_Generator;
+use SystemReport\Field;
+use SystemReport\Status;
+use SystemReport\Collectors\Collector;
+
+/**
+ * Test the Health_Score class.
+ */
+class HealthScoreTest extends WP_UnitTestCase {
+
+	/**
+	 * Health score instance.
+	 *
+	 * @var Health_Score
+	 */
+	private Health_Score $health_score;
+
+	/**
+	 * Report generator instance.
+	 *
+	 * @var Report_Generator
+	 */
+	private Report_Generator $generator;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		$this->generator    = new Report_Generator();
+		$this->health_score = new Health_Score( $this->generator );
+	}
+
+	/**
+	 * Test that a perfect report yields a perfect score.
+	 */
+	public function test_all_good_returns_perfect_score(): void {
+		$report = $this->build_report( array(
+			'security' => array(
+				$this->make_field( 'Test', 'OK', Status::Good ),
+				$this->make_field( 'Test 2', 'OK', Status::Good ),
+			),
+		) );
+
+		$result = $this->health_score->calculate( $report );
+
+		$this->assertSame( 100, $result['score'] );
+		$this->assertSame( 'A+', $result['grade'] );
+	}
+
+	/**
+	 * Test that all critical fields yield score of 0.
+	 */
+	public function test_all_critical_returns_zero_score(): void {
+		$report = $this->build_report( array(
+			'security' => array(
+				$this->make_field( 'Vuln', 'Bad', Status::Critical ),
+				$this->make_field( 'Vuln 2', 'Bad', Status::Critical ),
+			),
+		) );
+
+		$result = $this->health_score->calculate( $report );
+
+		$this->assertSame( 0, $result['score'] );
+		$this->assertSame( 'F', $result['grade'] );
+	}
+
+	/**
+	 * Test that a mix of statuses produces a weighted result.
+	 */
+	public function test_mixed_statuses_produce_weighted_score(): void {
+		$report = $this->build_report( array(
+			'security' => array(
+				$this->make_field( 'Good', 'OK', Status::Good ),
+				$this->make_field( 'Bad', 'Issue', Status::Warning ),
+			),
+		) );
+
+		$result = $this->health_score->calculate( $report );
+
+		// (100 + 40) / 2 = 70.
+		$this->assertSame( 70, $result['score'] );
+		$this->assertSame( 'B', $result['grade'] );
+	}
+
+	/**
+	 * Test that info fields are excluded from scoring.
+	 */
+	public function test_info_fields_excluded_from_scoring(): void {
+		$report = $this->build_report( array(
+			'security' => array(
+				$this->make_field( 'Good', 'OK', Status::Good ),
+				$this->make_field( 'Version', '1.0', Status::Info ),
+			),
+		) );
+
+		$result = $this->health_score->calculate( $report );
+
+		// Only the Good field is scored → 100.
+		$this->assertSame( 100, $result['score'] );
+		$this->assertSame( 1, $result['summary']['info'] );
+	}
+
+	/**
+	 * Test that empty report returns 100.
+	 */
+	public function test_empty_report_returns_perfect_score(): void {
+		$result = $this->health_score->calculate( array() );
+
+		$this->assertSame( 100, $result['score'] );
+		$this->assertSame( 'A+', $result['grade'] );
+	}
+
+	/**
+	 * Test that category weighting affects the score.
+	 */
+	public function test_category_weighting(): void {
+		// Security (weight 3.0) all good, performance (weight 2.5) all critical.
+		$report = $this->build_report( array(
+			'security'    => array(
+				$this->make_field( 'Sec', 'OK', Status::Good ),
+			),
+			'performance' => array(
+				$this->make_field( 'Perf', 'Slow', Status::Critical ),
+			),
+		) );
+
+		$result = $this->health_score->calculate( $report );
+
+		// Weighted: (100 * 3.0 + 0 * 2.5) / (3.0 + 2.5) = 300 / 5.5 ≈ 55.
+		$this->assertSame( 55, $result['score'] );
+	}
+
+	/**
+	 * Test that the breakdown includes correct per-section data.
+	 */
+	public function test_breakdown_structure(): void {
+		$report = $this->build_report( array(
+			'security' => array(
+				$this->make_field( 'A', 'OK', Status::Good ),
+				$this->make_field( 'B', 'Warn', Status::Warning ),
+				$this->make_field( 'C', 'Bad', Status::Critical ),
+			),
+		) );
+
+		$result = $this->health_score->calculate( $report );
+
+		$this->assertArrayHasKey( 'security', $result['breakdown'] );
+
+		$section = $result['breakdown']['security'];
+		$this->assertSame( 3, $section['field_count'] );
+		$this->assertSame( 1, $section['warnings'] );
+		$this->assertSame( 1, $section['criticals'] );
+		$this->assertSame( 3.0, $section['weight'] );
+	}
+
+	/**
+	 * Test that the summary aggregates correctly across sections.
+	 */
+	public function test_summary_counts(): void {
+		$report = $this->build_report( array(
+			'security' => array(
+				$this->make_field( 'A', 'OK', Status::Good ),
+				$this->make_field( 'B', 'Info', Status::Info ),
+			),
+			'performance' => array(
+				$this->make_field( 'C', 'Warn', Status::Warning ),
+				$this->make_field( 'D', 'Bad', Status::Critical ),
+			),
+		) );
+
+		$result = $this->health_score->calculate( $report );
+
+		$this->assertSame( 4, $result['summary']['total_fields'] );
+		$this->assertSame( 1, $result['summary']['good'] );
+		$this->assertSame( 1, $result['summary']['warnings'] );
+		$this->assertSame( 1, $result['summary']['criticals'] );
+		$this->assertSame( 1, $result['summary']['info'] );
+	}
+
+	/**
+	 * Test grade boundaries.
+	 */
+	public function test_grade_boundaries(): void {
+		$this->assertSame( 'A+', Health_Score::score_to_grade( 100 ) );
+		$this->assertSame( 'A+', Health_Score::score_to_grade( 95 ) );
+		$this->assertSame( 'A', Health_Score::score_to_grade( 94 ) );
+		$this->assertSame( 'A', Health_Score::score_to_grade( 80 ) );
+		$this->assertSame( 'B', Health_Score::score_to_grade( 79 ) );
+		$this->assertSame( 'B', Health_Score::score_to_grade( 65 ) );
+		$this->assertSame( 'C', Health_Score::score_to_grade( 64 ) );
+		$this->assertSame( 'C', Health_Score::score_to_grade( 50 ) );
+		$this->assertSame( 'D', Health_Score::score_to_grade( 49 ) );
+		$this->assertSame( 'D', Health_Score::score_to_grade( 35 ) );
+		$this->assertSame( 'F', Health_Score::score_to_grade( 34 ) );
+		$this->assertSame( 'F', Health_Score::score_to_grade( 0 ) );
+	}
+
+	/**
+	 * Test the health score filter.
+	 */
+	public function test_score_filter(): void {
+		add_filter( 'wp_system_report_health_score', function () {
+			return 42;
+		} );
+
+		$report = $this->build_report( array(
+			'security' => array(
+				$this->make_field( 'A', 'OK', Status::Good ),
+			),
+		) );
+
+		$result = $this->health_score->calculate( $report );
+
+		$this->assertSame( 42, $result['score'] );
+
+		remove_all_filters( 'wp_system_report_health_score' );
+	}
+
+	/**
+	 * Test the category weights filter.
+	 */
+	public function test_weights_filter(): void {
+		// Make security weight 0 and performance weight 10.
+		add_filter( 'wp_system_report_health_score_weights', function ( $weights ) {
+			$weights['security']    = 0.0;
+			$weights['performance'] = 10.0;
+			return $weights;
+		} );
+
+		$report = $this->build_report( array(
+			'security'    => array(
+				$this->make_field( 'Sec', 'Bad', Status::Critical ),
+			),
+			'performance' => array(
+				$this->make_field( 'Perf', 'OK', Status::Good ),
+			),
+		) );
+
+		$result = $this->health_score->calculate( $report );
+
+		// Security has weight 0 so doesn't count.
+		// Only performance: 100 * 10 / 10 = 100.
+		$this->assertSame( 100, $result['score'] );
+
+		remove_all_filters( 'wp_system_report_health_score_weights' );
+	}
+
+	/**
+	 * Test that sections with only info fields are excluded from breakdown.
+	 */
+	public function test_info_only_sections_excluded_from_breakdown(): void {
+		$report = $this->build_report( array(
+			'post_type_counts' => array(
+				$this->make_field( 'Posts', '42', Status::Info ),
+				$this->make_field( 'Pages', '10', Status::Info ),
+			),
+		) );
+
+		$result = $this->health_score->calculate( $report );
+
+		// Section has no scored fields so is excluded from breakdown.
+		$this->assertArrayNotHasKey( 'post_type_counts', $result['breakdown'] );
+		// But info fields are counted in summary.
+		$this->assertSame( 2, $result['summary']['info'] );
+	}
+
+	/**
+	 * Build a mock report structure.
+	 *
+	 * @param array<string, Field[]> $sections Map of section_id => fields.
+	 * @return array Report data in the standard format.
+	 */
+	private function build_report( array $sections ): array {
+		$report = array();
+
+		foreach ( $sections as $id => $fields ) {
+			$report[ $id ] = array(
+				'id'          => $id,
+				'label'       => ucfirst( str_replace( '_', ' ', $id ) ),
+				'description' => "Test section: {$id}",
+				'fields'      => $fields,
+			);
+		}
+
+		return $report;
+	}
+
+	/**
+	 * Create a Field instance.
+	 *
+	 * @param string $label  Field label.
+	 * @param string $value  Field value.
+	 * @param Status $status Field status.
+	 * @return Field Field instance.
+	 */
+	private function make_field( string $label, string $value, Status $status ): Field {
+		return new Field(
+			label:  $label,
+			value:  $value,
+			status: $status,
+		);
+	}
+}


### PR DESCRIPTION
## Summary
- Adds a weighted `Health_Score` class that computes an aggregate 0–100 score with letter grade (A+ through F) from collector report data
- Category weighting gives security (3.0x), performance (2.5x), and update health (2.5x) more influence on the final score; info-only fields are excluded
- New REST endpoint `GET /wp-system-report/v1/health-score` returns score, grade, per-section breakdown, and field status summary
- Feature-gated via `Features::has_health_score()` for Pro-ready separation
- Filterable via `wp_system_report_health_score` (score) and `wp_system_report_health_score_weights` (category weights)

## Test plan
- [ ] Verify `HealthScoreTest` PHPUnit tests pass (14 test cases covering perfect score, zero score, mixed, weighting, filters, edge cases)
- [ ] PHPCS clean across all PHP versions (8.1–8.4)
- [ ] PHPStan passes with `--memory-limit=1G`
- [ ] Rector dry-run clean
- [ ] Manual verification: hit `GET /wp-system-report/v1/health-score` REST endpoint and confirm response envelope structure

## Summary by Sourcery

Introduce a weighted health score system that aggregates system report data into a single graded score and exposes it via a secured REST API endpoint.

New Features:
- Add a Health_Score service that computes a 0–100 health score with letter grade and per-section breakdown from system report data.
- Expose the computed health score via a new GET /wp-system-report/v1/health-score REST endpoint returning score, grade, breakdown, and summary.
- Gate access to the health score feature behind the Pro tier feature flag.

Enhancements:
- Wire the health score calculator and controller into the main plugin lifecycle and REST route registration.
- Allow filtering of health score values and category weights for extensibility.

Tests:
- Add HealthScoreTest PHPUnit test suite covering scoring logic, weighting, filters, grading, and edge cases.