### PR TITLE
Add report diffing engine (Phase 5.5)

### DIFF
--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -106,6 +106,16 @@ class Plugin {
 	private ?\SystemReport\Abilities_Provider $abilities_provider = null;
 
 	/**
+	 * Report diff engine instance.
+	 */
+	private \SystemReport\Report_Diff $report_diff;
+
+	/**
+	 * Report diff controller instance.
+	 */
+	private \SystemReport\Report_Diff_Controller $report_diff_controller;
+
+	/**
 	 * GitHub updater instance.
 	 *
 	 * Stored to prevent garbage collection; hooks are registered in the constructor.
@@ -155,6 +165,13 @@ class Plugin {
 		if ( Features::has_health_score() ) {
 			$this->health_score_controller = new Health_Score_Controller( $this->health_score );
 		}
+
+		$this->report_diff            = new Report_Diff();
+		$this->report_diff_controller = new Report_Diff_Controller(
+			$this->report_diff,
+			$this->report_generator,
+			$this->health_score
+		);
 
 		$this->ai_context_generator    = new AI_Context_Generator( $this->report_generator );
 		$webhook_dispatcher            = new Webhook_Dispatcher();
@@ -249,6 +266,7 @@ class Plugin {
 		if ( null !== $this->report_history_controller ) {
 			add_action( 'rest_api_init', array( $this->report_history_controller, 'register_routes' ) );
 		}
+		add_action( 'rest_api_init', array( $this->report_diff_controller, 'register_routes' ) );
 		add_action( 'admin_enqueue_scripts', array( $this->admin_page, 'enqueue_assets' ) );
 
 		// Apply security hardening measures stored from previous fixer runs.
@@ -314,6 +332,15 @@ class Plugin {
 	 */
 	public function get_report_history(): ?Report_History {
 		return $this->report_history;
+	}
+
+	/**
+	 * Get the report diff engine.
+	 *
+	 * @return Report_Diff The report diff engine instance.
+	 */
+	public function get_report_diff(): Report_Diff {
+		return $this->report_diff;
 	}
 
 	/**

--- a/includes/class-report-diff-controller.php
+++ b/includes/class-report-diff-controller.php
@@ -1,0 +1,219 @@
+<?php
+/**
+ * Report diff REST controller.
+ *
+ * @package SystemReport
+ */
+
+namespace SystemReport;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST API controller for comparing two report snapshots.
+ *
+ * Provides endpoints to generate a structured diff between two historical
+ * snapshots (by ID) or between the current live report and a historical
+ * snapshot.
+ */
+class Report_Diff_Controller extends \WP_REST_Controller {
+
+	/**
+	 * Route namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wp-system-report/v1';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'diff';
+
+	/**
+	 * Report diff engine.
+	 */
+	private Report_Diff $diff;
+
+	/**
+	 * Report history instance (nullable — may not be available).
+	 */
+	private ?Report_History $history;
+
+	/**
+	 * Report generator instance for live reports.
+	 */
+	private Report_Generator $report_generator;
+
+	/**
+	 * Health score calculator.
+	 */
+	private Health_Score $health_score;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Report_Diff      $diff             Diff engine instance.
+	 * @param Report_Generator $report_generator Report generator instance.
+	 * @param Health_Score     $health_score     Health score calculator.
+	 * @param Report_History|null $history        Report history instance (null if disabled).
+	 */
+	public function __construct(
+		Report_Diff $diff,
+		Report_Generator $report_generator,
+		Health_Score $health_score,
+		?Report_History $history = null
+	) {
+		$this->diff             = $diff;
+		$this->report_generator = $report_generator;
+		$this->health_score     = $health_score;
+		$this->history          = $history;
+	}
+
+	/**
+	 * Register REST routes.
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => \WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'compare_snapshots' ),
+					'permission_callback' => array( $this, 'check_permission' ),
+					'args'                => array(
+						'before' => array(
+							'description' => __( 'Snapshot ID for the older report, or "current" for a live report.', 'wp-system-report' ),
+							'type'        => array( 'integer', 'string' ),
+							'required'    => true,
+						),
+						'after'  => array(
+							'description' => __( 'Snapshot ID for the newer report, or "current" for a live report.', 'wp-system-report' ),
+							'type'        => array( 'integer', 'string' ),
+							'required'    => true,
+						),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Check permissions.
+	 *
+	 * @return \WP_Error|bool True if the request has permission, WP_Error otherwise.
+	 */
+	public function check_permission(): \WP_Error|bool {
+		/** This filter is documented in includes/class-rest-controller.php */
+		$capability = apply_filters( 'wp_system_report_capability', 'manage_options' );
+
+		if ( ! current_user_can( $capability ) ) {
+			return new \WP_Error(
+				'rest_forbidden',
+				__( 'Sorry, you are not allowed to compare reports.', 'wp-system-report' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Compare two snapshots.
+	 *
+	 * @param \WP_REST_Request $request The request object.
+	 * @return \WP_REST_Response|\WP_Error The diff result or an error.
+	 */
+	public function compare_snapshots( \WP_REST_Request $request ) {
+		$before_id = $request->get_param( 'before' );
+		$after_id  = $request->get_param( 'after' );
+
+		$before_result = $this->resolve_report( $before_id );
+		if ( is_wp_error( $before_result ) ) {
+			return $before_result;
+		}
+
+		$after_result = $this->resolve_report( $after_id );
+		if ( is_wp_error( $after_result ) ) {
+			return $after_result;
+		}
+
+		$diff = $this->diff->compare(
+			$before_result['report'],
+			$after_result['report'],
+			$before_result['label'],
+			$after_result['label']
+		);
+
+		// Add health score comparison if available.
+		$diff['health_score'] = array(
+			'before' => $before_result['score'] ?? null,
+			'after'  => $after_result['score'] ?? null,
+		);
+
+		return REST_Envelope::success( $diff );
+	}
+
+	/**
+	 * Resolve a report reference to actual report data.
+	 *
+	 * Accepts "current" for a live report or an integer snapshot ID.
+	 *
+	 * @param int|string $reference The snapshot ID or "current".
+	 * @return array{report: array, label: string, score: array|null}|\WP_Error
+	 */
+	private function resolve_report( $reference ): array|\WP_Error {
+		if ( 'current' === $reference ) {
+			$report     = $this->report_generator->generate();
+			$score_data = $this->health_score->calculate( $report );
+
+			return array(
+				'report' => $report,
+				'label'  => __( 'Current', 'wp-system-report' ),
+				'score'  => array(
+					'score' => $score_data['score'],
+					'grade' => $score_data['grade'],
+				),
+			);
+		}
+
+		if ( null === $this->history ) {
+			return new \WP_Error(
+				'rest_report_history_disabled',
+				__( 'Report history is not available.', 'wp-system-report' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$snapshot_id = (int) $reference;
+		if ( $snapshot_id < 1 ) {
+			return new \WP_Error(
+				'rest_invalid_snapshot_id',
+				__( 'Invalid snapshot ID.', 'wp-system-report' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$snapshot = $this->history->get_snapshot( $snapshot_id );
+		if ( null === $snapshot ) {
+			return new \WP_Error(
+				'rest_snapshot_not_found',
+				/* translators: %d: snapshot ID */
+				sprintf( __( 'Snapshot %d not found.', 'wp-system-report' ), $snapshot_id ),
+				array( 'status' => 404 )
+			);
+		}
+
+		return array(
+			'report' => $snapshot['report_data'],
+			'label'  => $snapshot['created_at'] ?? '',
+			'score'  => array(
+				'score' => $snapshot['score'] ?? null,
+				'grade' => $snapshot['grade'] ?? null,
+			),
+		);
+	}
+}

--- a/includes/class-report-diff.php
+++ b/includes/class-report-diff.php
@@ -1,0 +1,330 @@
+<?php
+/**
+ * Report diff engine.
+ *
+ * @package SystemReport
+ */
+
+namespace SystemReport;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Compares two report snapshots and produces a structured diff.
+ *
+ * The diff identifies:
+ * - Sections added or removed between snapshots.
+ * - Fields added or removed within sections.
+ * - Changed field values and status transitions.
+ * - Overall summary of improvements, degradations, and unchanged items.
+ *
+ * Status transitions are classified as:
+ * - **Improved**: status moved toward 'good' (e.g. critical → warning, warning → good).
+ * - **Degraded**: status moved away from 'good' (e.g. good → warning, warning → critical).
+ * - **Changed**: value changed but status remained the same.
+ */
+class Report_Diff {
+
+	/**
+	 * Numeric weight for each status, higher = better.
+	 *
+	 * @var array<string, int>
+	 */
+	private const STATUS_RANK = array(
+		'critical' => 0,
+		'warning'  => 1,
+		'info'     => 2,
+		'good'     => 3,
+	);
+
+	/**
+	 * Compare two reports and produce a structured diff.
+	 *
+	 * @param array  $before  The older report data (keyed by section ID).
+	 * @param array  $after   The newer report data (keyed by section ID).
+	 * @param string $before_label Optional label for the before snapshot (e.g. date).
+	 * @param string $after_label  Optional label for the after snapshot (e.g. date).
+	 * @return array{
+	 *     sections: array<string, array{
+	 *         label: string,
+	 *         change_type: string,
+	 *         fields: array
+	 *     }>,
+	 *     summary: array{
+	 *         total_changes: int,
+	 *         improved: int,
+	 *         degraded: int,
+	 *         added: int,
+	 *         removed: int,
+	 *         changed: int,
+	 *         unchanged_sections: int
+	 *     },
+	 *     labels: array{before: string, after: string}
+	 * }
+	 */
+	public function compare( array $before, array $after, string $before_label = '', string $after_label = '' ): array {
+		$sections = array();
+		$summary  = array(
+			'total_changes'      => 0,
+			'improved'           => 0,
+			'degraded'           => 0,
+			'added'              => 0,
+			'removed'            => 0,
+			'changed'            => 0,
+			'unchanged_sections' => 0,
+		);
+
+		$all_section_ids = array_unique( array_merge( array_keys( $before ), array_keys( $after ) ) );
+
+		foreach ( $all_section_ids as $section_id ) {
+			$in_before = isset( $before[ $section_id ] );
+			$in_after  = isset( $after[ $section_id ] );
+
+			if ( $in_before && ! $in_after ) {
+				// Section removed.
+				$label                     = $before[ $section_id ]['label'] ?? $section_id;
+				$field_count               = count( $before[ $section_id ]['fields'] ?? array() );
+				$sections[ $section_id ]   = array(
+					'label'       => $label,
+					'change_type' => 'removed',
+					'fields'      => array(),
+				);
+				$summary['removed']       += $field_count;
+				$summary['total_changes'] += $field_count;
+				continue;
+			}
+
+			if ( ! $in_before && $in_after ) {
+				// Section added.
+				$label                     = $after[ $section_id ]['label'] ?? $section_id;
+				$field_count               = count( $after[ $section_id ]['fields'] ?? array() );
+				$sections[ $section_id ]   = array(
+					'label'       => $label,
+					'change_type' => 'added',
+					'fields'      => array(),
+				);
+				$summary['added']         += $field_count;
+				$summary['total_changes'] += $field_count;
+				continue;
+			}
+
+			// Section exists in both — compare fields.
+			$section_diff = $this->diff_section(
+				$before[ $section_id ],
+				$after[ $section_id ],
+				$summary
+			);
+
+			if ( empty( $section_diff['fields'] ) ) {
+				++$summary['unchanged_sections'];
+				continue;
+			}
+
+			$sections[ $section_id ] = $section_diff;
+		}
+
+		/**
+		 * Filter the computed report diff.
+		 *
+		 * @param array $diff     The full diff result.
+		 * @param array $before   The older report data.
+		 * @param array $after    The newer report data.
+		 */
+		$result = array(
+			'sections' => $sections,
+			'summary'  => $summary,
+			'labels'   => array(
+				'before' => $before_label,
+				'after'  => $after_label,
+			),
+		);
+
+		return apply_filters( 'wp_system_report_diff', $result, $before, $after );
+	}
+
+	/**
+	 * Diff a single section's fields.
+	 *
+	 * @param array $before_section  The older section data.
+	 * @param array $after_section   The newer section data.
+	 * @param array $summary         Reference to the summary counters (modified in place).
+	 * @return array{label: string, change_type: string, fields: array}
+	 */
+	private function diff_section( array $before_section, array $after_section, array &$summary ): array {
+		$label         = $after_section['label'] ?? $before_section['label'] ?? '';
+		$before_fields = $this->index_fields( $before_section['fields'] ?? array() );
+		$after_fields  = $this->index_fields( $after_section['fields'] ?? array() );
+		$all_keys      = array_unique( array_merge( array_keys( $before_fields ), array_keys( $after_fields ) ) );
+		$field_diffs   = array();
+
+		foreach ( $all_keys as $key ) {
+			$in_before = isset( $before_fields[ $key ] );
+			$in_after  = isset( $after_fields[ $key ] );
+
+			if ( $in_before && ! $in_after ) {
+				$field_diffs[] = array(
+					'label'       => $this->get_field_label( $before_fields[ $key ] ),
+					'change_type' => 'removed',
+					'before'      => $this->extract_field_summary( $before_fields[ $key ] ),
+					'after'       => null,
+				);
+				++$summary['removed'];
+				++$summary['total_changes'];
+				continue;
+			}
+
+			if ( ! $in_before && $in_after ) {
+				$field_diffs[] = array(
+					'label'       => $this->get_field_label( $after_fields[ $key ] ),
+					'change_type' => 'added',
+					'before'      => null,
+					'after'       => $this->extract_field_summary( $after_fields[ $key ] ),
+				);
+				++$summary['added'];
+				++$summary['total_changes'];
+				continue;
+			}
+
+			// Both exist — check for changes.
+			$change = $this->diff_field( $before_fields[ $key ], $after_fields[ $key ] );
+
+			if ( null !== $change ) {
+				$field_diffs[] = $change;
+
+				switch ( $change['change_type'] ) {
+					case 'improved':
+						++$summary['improved'];
+						break;
+					case 'degraded':
+						++$summary['degraded'];
+						break;
+					default:
+						++$summary['changed'];
+						break;
+				}
+				++$summary['total_changes'];
+			}
+		}
+
+		return array(
+			'label'       => $label,
+			'change_type' => 'modified',
+			'fields'      => $field_diffs,
+		);
+	}
+
+	/**
+	 * Compare two individual fields.
+	 *
+	 * @param Field|array $before The older field.
+	 * @param Field|array $after  The newer field.
+	 * @return array|null Diff entry or null if unchanged.
+	 */
+	private function diff_field( $before, $after ): ?array {
+		$before_value  = $this->get_field_value( $before );
+		$after_value   = $this->get_field_value( $after );
+		$before_status = Field::get_status_string( $before );
+		$after_status  = Field::get_status_string( $after );
+
+		// No change.
+		if ( $before_value === $after_value && $before_status === $after_status ) {
+			return null;
+		}
+
+		$change_type = 'changed';
+		if ( $before_status !== $after_status ) {
+			$change_type = $this->classify_status_change( $before_status, $after_status );
+		}
+
+		return array(
+			'label'       => $this->get_field_label( $after ),
+			'change_type' => $change_type,
+			'before'      => $this->extract_field_summary( $before ),
+			'after'       => $this->extract_field_summary( $after ),
+		);
+	}
+
+	/**
+	 * Classify a status transition as improved or degraded.
+	 *
+	 * @param string $before_status The older status.
+	 * @param string $after_status  The newer status.
+	 * @return string 'improved', 'degraded', or 'changed'.
+	 */
+	private function classify_status_change( string $before_status, string $after_status ): string {
+		$before_rank = self::STATUS_RANK[ $before_status ] ?? 2;
+		$after_rank  = self::STATUS_RANK[ $after_status ] ?? 2;
+
+		if ( $after_rank > $before_rank ) {
+			return 'improved';
+		}
+
+		if ( $after_rank < $before_rank ) {
+			return 'degraded';
+		}
+
+		return 'changed';
+	}
+
+	/**
+	 * Index an array of fields by their label for comparison.
+	 *
+	 * @param array $fields Array of Field objects or arrays.
+	 * @return array<string, Field|array> Fields indexed by label.
+	 */
+	private function index_fields( array $fields ): array {
+		$indexed = array();
+
+		foreach ( $fields as $field ) {
+			$key = $this->get_field_label( $field );
+
+			// Use label as the key; skip duplicates (keep first).
+			if ( ! isset( $indexed[ $key ] ) ) {
+				$indexed[ $key ] = $field;
+			}
+		}
+
+		return $indexed;
+	}
+
+	/**
+	 * Get the label from a field.
+	 *
+	 * @param Field|array $field A Field value object or associative array.
+	 * @return string The field label.
+	 */
+	private function get_field_label( $field ): string {
+		if ( $field instanceof Field ) {
+			return $field->label;
+		}
+
+		return (string) ( $field['label'] ?? '' );
+	}
+
+	/**
+	 * Get the display value from a field.
+	 *
+	 * @param Field|array $field A Field value object or associative array.
+	 * @return string The field value.
+	 */
+	private function get_field_value( $field ): string {
+		if ( $field instanceof Field ) {
+			return $field->value;
+		}
+
+		return (string) ( $field['value'] ?? '' );
+	}
+
+	/**
+	 * Extract a compact summary of a field for diff output.
+	 *
+	 * @param Field|array $field A Field value object or associative array.
+	 * @return array{value: string, status: string}
+	 */
+	private function extract_field_summary( $field ): array {
+		return array(
+			'value'  => $this->get_field_value( $field ),
+			'status' => Field::get_status_string( $field ),
+		);
+	}
+}

--- a/tests/ReportDiffTest.php
+++ b/tests/ReportDiffTest.php
@@ -1,0 +1,491 @@
+<?php
+/**
+ * Tests for the Report_Diff class.
+ *
+ * @package SystemReport
+ */
+
+namespace SystemReport\Tests;
+
+use PHPUnit\Framework\TestCase;
+use SystemReport\Field;
+use SystemReport\Report_Diff;
+use SystemReport\Status;
+
+/**
+ * @covers \SystemReport\Report_Diff
+ */
+class ReportDiffTest extends TestCase {
+
+	private Report_Diff $diff;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->diff = new Report_Diff();
+	}
+
+	/**
+	 * Create a sample report with configurable sections and fields.
+	 *
+	 * @param array $sections Map of section_id => array of Field configs.
+	 * @return array Report structure.
+	 */
+	private function create_report( array $sections ): array {
+		$report = array();
+
+		foreach ( $sections as $section_id => $fields ) {
+			$field_objects = array();
+			foreach ( $fields as $field_config ) {
+				$field_objects[] = new Field(
+					$field_config['label'],
+					$field_config['value'],
+					$field_config['value'],
+					Status::from_legacy( $field_config['status'] ?? 'info' )
+				);
+			}
+
+			$report[ $section_id ] = array(
+				'id'          => $section_id,
+				'label'       => ucfirst( str_replace( '_', ' ', $section_id ) ),
+				'description' => "Description for {$section_id}.",
+				'fields'      => $field_objects,
+			);
+		}
+
+		return $report;
+	}
+
+	public function test_identical_reports_produce_empty_diff(): void {
+		$report = $this->create_report(
+			array(
+				'security' => array(
+					array( 'label' => 'SSL', 'value' => 'Enabled', 'status' => 'good' ),
+				),
+			)
+		);
+
+		$result = $this->diff->compare( $report, $report );
+
+		$this->assertEmpty( $result['sections'] );
+		$this->assertSame( 0, $result['summary']['total_changes'] );
+		$this->assertSame( 1, $result['summary']['unchanged_sections'] );
+	}
+
+	public function test_added_section_detected(): void {
+		$before = $this->create_report( array() );
+		$after  = $this->create_report(
+			array(
+				'security' => array(
+					array( 'label' => 'SSL', 'value' => 'Enabled', 'status' => 'good' ),
+					array( 'label' => 'HSTS', 'value' => 'Missing', 'status' => 'warning' ),
+				),
+			)
+		);
+
+		$result = $this->diff->compare( $before, $after );
+
+		$this->assertArrayHasKey( 'security', $result['sections'] );
+		$this->assertSame( 'added', $result['sections']['security']['change_type'] );
+		$this->assertSame( 2, $result['summary']['added'] );
+		$this->assertSame( 2, $result['summary']['total_changes'] );
+	}
+
+	public function test_removed_section_detected(): void {
+		$before = $this->create_report(
+			array(
+				'security' => array(
+					array( 'label' => 'SSL', 'value' => 'Enabled', 'status' => 'good' ),
+				),
+			)
+		);
+		$after = $this->create_report( array() );
+
+		$result = $this->diff->compare( $before, $after );
+
+		$this->assertArrayHasKey( 'security', $result['sections'] );
+		$this->assertSame( 'removed', $result['sections']['security']['change_type'] );
+		$this->assertSame( 1, $result['summary']['removed'] );
+	}
+
+	public function test_added_field_detected(): void {
+		$before = $this->create_report(
+			array(
+				'security' => array(
+					array( 'label' => 'SSL', 'value' => 'Enabled', 'status' => 'good' ),
+				),
+			)
+		);
+		$after = $this->create_report(
+			array(
+				'security' => array(
+					array( 'label' => 'SSL', 'value' => 'Enabled', 'status' => 'good' ),
+					array( 'label' => 'HSTS', 'value' => 'Missing', 'status' => 'warning' ),
+				),
+			)
+		);
+
+		$result = $this->diff->compare( $before, $after );
+
+		$this->assertArrayHasKey( 'security', $result['sections'] );
+		$fields = $result['sections']['security']['fields'];
+		$this->assertCount( 1, $fields );
+		$this->assertSame( 'HSTS', $fields[0]['label'] );
+		$this->assertSame( 'added', $fields[0]['change_type'] );
+	}
+
+	public function test_removed_field_detected(): void {
+		$before = $this->create_report(
+			array(
+				'security' => array(
+					array( 'label' => 'SSL', 'value' => 'Enabled', 'status' => 'good' ),
+					array( 'label' => 'HSTS', 'value' => 'Missing', 'status' => 'warning' ),
+				),
+			)
+		);
+		$after = $this->create_report(
+			array(
+				'security' => array(
+					array( 'label' => 'SSL', 'value' => 'Enabled', 'status' => 'good' ),
+				),
+			)
+		);
+
+		$result = $this->diff->compare( $before, $after );
+
+		$fields = $result['sections']['security']['fields'];
+		$this->assertCount( 1, $fields );
+		$this->assertSame( 'HSTS', $fields[0]['label'] );
+		$this->assertSame( 'removed', $fields[0]['change_type'] );
+	}
+
+	public function test_value_change_detected(): void {
+		$before = $this->create_report(
+			array(
+				'server' => array(
+					array( 'label' => 'PHP Version', 'value' => '8.1.0', 'status' => 'good' ),
+				),
+			)
+		);
+		$after = $this->create_report(
+			array(
+				'server' => array(
+					array( 'label' => 'PHP Version', 'value' => '8.3.0', 'status' => 'good' ),
+				),
+			)
+		);
+
+		$result = $this->diff->compare( $before, $after );
+
+		$fields = $result['sections']['server']['fields'];
+		$this->assertCount( 1, $fields );
+		$this->assertSame( 'changed', $fields[0]['change_type'] );
+		$this->assertSame( '8.1.0', $fields[0]['before']['value'] );
+		$this->assertSame( '8.3.0', $fields[0]['after']['value'] );
+	}
+
+	public function test_status_improvement_detected(): void {
+		$before = $this->create_report(
+			array(
+				'security' => array(
+					array( 'label' => 'SSL', 'value' => 'Disabled', 'status' => 'critical' ),
+				),
+			)
+		);
+		$after = $this->create_report(
+			array(
+				'security' => array(
+					array( 'label' => 'SSL', 'value' => 'Enabled', 'status' => 'good' ),
+				),
+			)
+		);
+
+		$result = $this->diff->compare( $before, $after );
+
+		$fields = $result['sections']['security']['fields'];
+		$this->assertSame( 'improved', $fields[0]['change_type'] );
+		$this->assertSame( 1, $result['summary']['improved'] );
+	}
+
+	public function test_status_degradation_detected(): void {
+		$before = $this->create_report(
+			array(
+				'security' => array(
+					array( 'label' => 'SSL', 'value' => 'Enabled', 'status' => 'good' ),
+				),
+			)
+		);
+		$after = $this->create_report(
+			array(
+				'security' => array(
+					array( 'label' => 'SSL', 'value' => 'Expired', 'status' => 'critical' ),
+				),
+			)
+		);
+
+		$result = $this->diff->compare( $before, $after );
+
+		$fields = $result['sections']['security']['fields'];
+		$this->assertSame( 'degraded', $fields[0]['change_type'] );
+		$this->assertSame( 1, $result['summary']['degraded'] );
+	}
+
+	public function test_warning_to_good_is_improved(): void {
+		$before = $this->create_report(
+			array(
+				'perf' => array(
+					array( 'label' => 'Cache', 'value' => 'File', 'status' => 'warning' ),
+				),
+			)
+		);
+		$after = $this->create_report(
+			array(
+				'perf' => array(
+					array( 'label' => 'Cache', 'value' => 'Redis', 'status' => 'good' ),
+				),
+			)
+		);
+
+		$result = $this->diff->compare( $before, $after );
+
+		$this->assertSame( 'improved', $result['sections']['perf']['fields'][0]['change_type'] );
+	}
+
+	public function test_good_to_warning_is_degraded(): void {
+		$before = $this->create_report(
+			array(
+				'perf' => array(
+					array( 'label' => 'Cache', 'value' => 'Redis', 'status' => 'good' ),
+				),
+			)
+		);
+		$after = $this->create_report(
+			array(
+				'perf' => array(
+					array( 'label' => 'Cache', 'value' => 'File', 'status' => 'warning' ),
+				),
+			)
+		);
+
+		$result = $this->diff->compare( $before, $after );
+
+		$this->assertSame( 'degraded', $result['sections']['perf']['fields'][0]['change_type'] );
+	}
+
+	public function test_labels_passed_through(): void {
+		$before = $this->create_report( array() );
+		$after  = $this->create_report( array() );
+
+		$result = $this->diff->compare( $before, $after, '2024-01-01', '2024-06-01' );
+
+		$this->assertSame( '2024-01-01', $result['labels']['before'] );
+		$this->assertSame( '2024-06-01', $result['labels']['after'] );
+	}
+
+	public function test_multiple_sections_with_mixed_changes(): void {
+		$before = $this->create_report(
+			array(
+				'security' => array(
+					array( 'label' => 'SSL', 'value' => 'Enabled', 'status' => 'good' ),
+					array( 'label' => 'Firewall', 'value' => 'Active', 'status' => 'good' ),
+				),
+				'server'   => array(
+					array( 'label' => 'PHP Version', 'value' => '8.1.0', 'status' => 'warning' ),
+				),
+				'old_section' => array(
+					array( 'label' => 'Legacy', 'value' => 'Data', 'status' => 'info' ),
+				),
+			)
+		);
+		$after = $this->create_report(
+			array(
+				'security' => array(
+					array( 'label' => 'SSL', 'value' => 'Enabled', 'status' => 'good' ),
+					array( 'label' => 'Firewall', 'value' => 'Inactive', 'status' => 'critical' ),
+				),
+				'server'   => array(
+					array( 'label' => 'PHP Version', 'value' => '8.3.0', 'status' => 'good' ),
+				),
+				'new_section' => array(
+					array( 'label' => 'New Check', 'value' => 'OK', 'status' => 'good' ),
+				),
+			)
+		);
+
+		$result = $this->diff->compare( $before, $after );
+
+		// Security: Firewall degraded.
+		$this->assertSame( 1, $result['summary']['degraded'] );
+		// Server: PHP improved.
+		$this->assertSame( 1, $result['summary']['improved'] );
+		// old_section removed (1 field).
+		$this->assertSame( 1, $result['summary']['removed'] );
+		// new_section added (1 field).
+		$this->assertSame( 1, $result['summary']['added'] );
+		$this->assertSame( 4, $result['summary']['total_changes'] );
+	}
+
+	public function test_legacy_array_fields_supported(): void {
+		$before = array(
+			'section' => array(
+				'id'     => 'section',
+				'label'  => 'Section',
+				'fields' => array(
+					array( 'label' => 'Field A', 'value' => 'old', 'status' => 'good' ),
+				),
+			),
+		);
+		$after = array(
+			'section' => array(
+				'id'     => 'section',
+				'label'  => 'Section',
+				'fields' => array(
+					array( 'label' => 'Field A', 'value' => 'new', 'status' => 'warning' ),
+				),
+			),
+		);
+
+		$result = $this->diff->compare( $before, $after );
+
+		$fields = $result['sections']['section']['fields'];
+		$this->assertCount( 1, $fields );
+		$this->assertSame( 'degraded', $fields[0]['change_type'] );
+		$this->assertSame( 'old', $fields[0]['before']['value'] );
+		$this->assertSame( 'new', $fields[0]['after']['value'] );
+	}
+
+	public function test_empty_reports_produce_no_diff(): void {
+		$result = $this->diff->compare( array(), array() );
+
+		$this->assertEmpty( $result['sections'] );
+		$this->assertSame( 0, $result['summary']['total_changes'] );
+	}
+
+	public function test_field_summary_contains_value_and_status(): void {
+		$before = $this->create_report(
+			array(
+				'section' => array(
+					array( 'label' => 'Test', 'value' => 'before_val', 'status' => 'good' ),
+				),
+			)
+		);
+		$after = $this->create_report(
+			array(
+				'section' => array(
+					array( 'label' => 'Test', 'value' => 'after_val', 'status' => 'warning' ),
+				),
+			)
+		);
+
+		$result = $this->diff->compare( $before, $after );
+
+		$field = $result['sections']['section']['fields'][0];
+		$this->assertArrayHasKey( 'value', $field['before'] );
+		$this->assertArrayHasKey( 'status', $field['before'] );
+		$this->assertArrayHasKey( 'value', $field['after'] );
+		$this->assertArrayHasKey( 'status', $field['after'] );
+		$this->assertSame( 'before_val', $field['before']['value'] );
+		$this->assertSame( 'good', $field['before']['status'] );
+		$this->assertSame( 'after_val', $field['after']['value'] );
+		$this->assertSame( 'warning', $field['after']['status'] );
+	}
+
+	public function test_added_field_has_null_before(): void {
+		$before = $this->create_report(
+			array(
+				'section' => array(
+					array( 'label' => 'Existing', 'value' => 'Val', 'status' => 'good' ),
+				),
+			)
+		);
+		$after = $this->create_report(
+			array(
+				'section' => array(
+					array( 'label' => 'Existing', 'value' => 'Val', 'status' => 'good' ),
+					array( 'label' => 'New Field', 'value' => 'New', 'status' => 'info' ),
+				),
+			)
+		);
+
+		$result = $this->diff->compare( $before, $after );
+
+		$field = $result['sections']['section']['fields'][0];
+		$this->assertSame( 'added', $field['change_type'] );
+		$this->assertNull( $field['before'] );
+		$this->assertNotNull( $field['after'] );
+	}
+
+	public function test_removed_field_has_null_after(): void {
+		$before = $this->create_report(
+			array(
+				'section' => array(
+					array( 'label' => 'Existing', 'value' => 'Val', 'status' => 'good' ),
+					array( 'label' => 'Old Field', 'value' => 'Old', 'status' => 'info' ),
+				),
+			)
+		);
+		$after = $this->create_report(
+			array(
+				'section' => array(
+					array( 'label' => 'Existing', 'value' => 'Val', 'status' => 'good' ),
+				),
+			)
+		);
+
+		$result = $this->diff->compare( $before, $after );
+
+		$field = $result['sections']['section']['fields'][0];
+		$this->assertSame( 'removed', $field['change_type'] );
+		$this->assertNotNull( $field['before'] );
+		$this->assertNull( $field['after'] );
+	}
+
+	public function test_critical_to_warning_is_improved(): void {
+		$before = $this->create_report(
+			array(
+				'section' => array(
+					array( 'label' => 'Test', 'value' => 'Bad', 'status' => 'critical' ),
+				),
+			)
+		);
+		$after = $this->create_report(
+			array(
+				'section' => array(
+					array( 'label' => 'Test', 'value' => 'Better', 'status' => 'warning' ),
+				),
+			)
+		);
+
+		$result = $this->diff->compare( $before, $after );
+
+		$this->assertSame( 'improved', $result['sections']['section']['fields'][0]['change_type'] );
+	}
+
+	public function test_unchanged_section_not_in_output(): void {
+		$before = $this->create_report(
+			array(
+				'unchanged' => array(
+					array( 'label' => 'A', 'value' => 'V', 'status' => 'good' ),
+				),
+				'changed'   => array(
+					array( 'label' => 'B', 'value' => 'Old', 'status' => 'warning' ),
+				),
+			)
+		);
+		$after = $this->create_report(
+			array(
+				'unchanged' => array(
+					array( 'label' => 'A', 'value' => 'V', 'status' => 'good' ),
+				),
+				'changed'   => array(
+					array( 'label' => 'B', 'value' => 'New', 'status' => 'good' ),
+				),
+			)
+		);
+
+		$result = $this->diff->compare( $before, $after );
+
+		$this->assertArrayNotHasKey( 'unchanged', $result['sections'] );
+		$this->assertArrayHasKey( 'changed', $result['sections'] );
+		$this->assertSame( 1, $result['summary']['unchanged_sections'] );
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a `Report_Diff` engine that compares two report snapshots and produces a structured diff identifying added/removed sections and fields, value changes, and status transitions (improved/degraded/changed).
- Adds a `Report_Diff_Controller` REST endpoint (`POST /wp-system-report/v1/diff`) that accepts `before` and `after` params (snapshot IDs or `"current"` for live report comparison).
- Includes 18 comprehensive test cases covering all diff scenarios: identical reports, section/field additions/removals, status improvements and degradations, legacy array field support, and edge cases.
- Wires the diff engine into `Plugin` with constructor injection and REST route registration.

## Technical Details

- **Status ranking**: `critical=0, warning=1, info=2, good=3` — transitions to higher rank are "improved", lower rank are "degraded".
- **Field matching**: Fields are indexed by label within each section for comparison.
- **Optional history**: The controller accepts an optional `Report_History` dependency for loading stored snapshots, returning a clear error when history is unavailable.
- **Health score comparison**: Includes before/after health scores in the diff response.

## Test plan

- [ ] PHPCS passes on all PHP versions (8.1–8.4)
- [ ] PHPStan passes at configured level
- [ ] All 18 ReportDiffTest cases pass
- [ ] Rector dry-run shows no changes
- [ ] REST endpoint returns correct diff structure for two snapshot IDs
- [ ] REST endpoint handles `"current"` parameter for live comparison
- [ ] Graceful error when Report_History is unavailable and non-current snapshot requested

## Summary by Sourcery

Introduce a report diffing capability and REST endpoint to compare system report snapshots and expose structured change summaries.

New Features:
- Add a Report_Diff engine to compute structured diffs between two report snapshots, including section and field-level changes and status transitions.
- Expose a Report_Diff_Controller REST endpoint to compare two snapshots or a snapshot against the current report and return the diff plus health score comparison.
- Provide a public accessor on Plugin for the report diff engine.

Tests:
- Add a comprehensive ReportDiffTest suite covering section and field additions/removals, value changes, status improvements/degradations, legacy field formats, labels, and unchanged-section handling.