### PR TITLE
Fix report history Sourcery review feedback

### DIFF
--- a/includes/class-report-history.php
+++ b/includes/class-report-history.php
@@ -84,10 +84,18 @@ class Report_History {
 	 * creation in wp-admin/includes/schema.php. The schema uses two spaces
 	 * after PRIMARY KEY (a dbDelta requirement) and KEY for secondary indexes.
 	 *
+	 * No-ops when the report history feature gate is disabled, keeping
+	 * call sites simple (activation hook, admin_init) and avoiding
+	 * accidental table creation in Free tier.
+	 *
 	 * Should be called on plugin activation and checked via
 	 * needs_schema_update() on admin_init.
 	 */
 	public static function create_table(): void {
+		if ( ! Features::has_report_history() ) {
+			return;
+		}
+
 		global $wpdb;
 
 		$table_name      = self::get_table_name();
@@ -132,9 +140,16 @@ class Report_History {
 	/**
 	 * Check whether the schema needs to be created or upgraded.
 	 *
+	 * Returns false when the report history feature gate is disabled,
+	 * so call sites can remain simple.
+	 *
 	 * @return bool True if the schema needs updating.
 	 */
 	public static function needs_schema_update(): bool {
+		if ( ! Features::has_report_history() ) {
+			return false;
+		}
+
 		$installed = get_option( self::SCHEMA_OPTION, '' );
 		return self::SCHEMA_VERSION !== $installed;
 	}


### PR DESCRIPTION
## Summary

Addresses Sourcery review feedback from PR #38 that arrived after the merge.

- Replace `$wpdb->prepare()` `%i` identifier placeholders with direct table name interpolation plus `phpcs:ignore` annotations in `Report_History`. The `%i` placeholder is valid in WordPress 6.2+, but static analysis tools do not consistently recognize it.
- Gate `Report_History::create_table()` calls in the activation hook and `admin_init` behind `Features::has_report_history()` so the table is not created when the feature is disabled.

## Test plan

- [ ] All existing `ReportHistoryTest` tests continue to pass (table creation, CRUD, pagination, retention, compression round-trip)
- [ ] PHPCS passes without `%i`-related warnings
- [ ] PHPStan passes on all PHP versions
- [ ] Rector dry-run passes

## Summary by Sourcery

Gate report history table creation and schema checks behind the feature flag to avoid creating the table when the feature is disabled.

Enhancements:
- Short-circuit report history table creation when the report history feature is disabled.
- Short-circuit report history schema update checks when the report history feature is disabled.