### PR TITLE
Fix 3 critical security and data integrity issues

### DIFF
--- a/includes/class-error-log-reader.php
+++ b/includes/class-error-log-reader.php
@@ -150,13 +150,13 @@ class Error_Log_Reader {
 
 		// Check if within ABSPATH.
 		$abspath = defined( 'ABSPATH' ) ? realpath( ABSPATH ) : false;
-		if ( false !== $abspath && 0 === strpos( $real_path, $abspath ) ) {
+		if ( false !== $abspath && 0 === strpos( $real_path, rtrim( $abspath, '/' ) . '/' ) ) {
 			return true;
 		}
 
 		// Check if within WP_CONTENT_DIR.
 		$content_dir = defined( 'WP_CONTENT_DIR' ) ? realpath( WP_CONTENT_DIR ) : false;
-		if ( false !== $content_dir && 0 === strpos( $real_path, $content_dir ) ) {
+		if ( false !== $content_dir && 0 === strpos( $real_path, rtrim( $content_dir, '/' ) . '/' ) ) {
 			return true;
 		}
 
@@ -205,7 +205,7 @@ class Error_Log_Reader {
 					continue;
 				}
 
-				if ( 0 === strpos( $real_path, $real_allowed ) ) {
+				if ( 0 === strpos( $real_path, rtrim( $real_allowed, '/' ) . '/' ) ) {
 					return true;
 				}
 			}

--- a/includes/class-report-history.php
+++ b/includes/class-report-history.php
@@ -214,6 +214,10 @@ class Report_History {
 			if ( false === $compressed ) {
 				return false;
 			}
+
+			// Base64-encode the binary data so it survives UTF-8 storage.
+			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Encoding binary gzcompress output for safe DB storage, not obfuscation.
+			$compressed = base64_encode( $compressed );
 		} else {
 			// Store raw JSON when zlib is not available.
 			$compressed = $json;
@@ -523,6 +527,23 @@ class Report_History {
 	 */
 	private function decompress_report( string $data ): ?array {
 		if ( function_exists( 'gzuncompress' ) ) {
+			// Try base64-decoded gzuncompress first (current storage format).
+			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decoding base64-encoded gzcompress output from DB storage, not obfuscation.
+			$decoded_b64 = base64_decode( $data, true );
+
+			if ( false !== $decoded_b64 ) {
+				// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- gzuncompress emits E_WARNING on malformed data; suppressed to allow fallback.
+				$decompressed = @gzuncompress( $decoded_b64 );
+
+				if ( false !== $decompressed ) {
+					$decoded = json_decode( $decompressed, true );
+					if ( is_array( $decoded ) ) {
+						return $decoded;
+					}
+				}
+			}
+
+			// Legacy fallback: try raw binary gzuncompress (pre-fix storage).
 			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- gzuncompress emits E_WARNING on malformed data; suppressed to allow JSON fallback.
 			$decompressed = @gzuncompress( $data );
 

--- a/includes/fixers/class-security-hardener.php
+++ b/includes/fixers/class-security-hardener.php
@@ -260,11 +260,31 @@ class Security_Hardener implements Fixer {
 	}
 
 	/**
+	 * Permitted header names that may be sent by the hardener.
+	 *
+	 * Only headers in this list will be emitted at runtime, preventing
+	 * arbitrary header injection if the stored option is tampered with.
+	 *
+	 * @var array<string, true>
+	 */
+	private const ALLOWED_HEADER_NAMES = array(
+		'X-Content-Type-Options'    => true,
+		'X-Frame-Options'           => true,
+		'Referrer-Policy'           => true,
+		'Strict-Transport-Security' => true,
+		'Permissions-Policy'        => true,
+	);
+
+	/**
 	 * Apply runtime security hardening based on stored options.
 	 *
 	 * Called from the plugin's hook registration. This method:
 	 * - Adds the `xmlrpc_enabled` filter to disable XML-RPC
 	 * - Adds the `send_headers` action to send security headers
+	 *
+	 * Header names are validated against an explicit allowlist and both
+	 * names and values are rejected if they contain CR/LF characters to
+	 * prevent HTTP response-splitting attacks.
 	 */
 	public static function apply_runtime_hardening(): void {
 		$options = get_option( self::OPTION_KEY, array() );
@@ -278,9 +298,21 @@ class Security_Hardener implements Fixer {
 				'send_headers',
 				function () use ( $options ): void {
 					foreach ( $options['security_headers'] as $name => $value ) {
-						if ( ! headers_sent() ) {
-							header( sprintf( '%s: %s', $name, $value ) );
+						if ( headers_sent() ) {
+							break;
 						}
+
+						// Only permit explicitly allowed header names.
+						if ( ! isset( self::ALLOWED_HEADER_NAMES[ $name ] ) ) {
+							continue;
+						}
+
+						// Reject values containing CR or LF to prevent response-splitting.
+						if ( preg_match( '/[\r\n]/', $name . $value ) ) {
+							continue;
+						}
+
+						header( sprintf( '%s: %s', $name, $value ) );
 					}
 				}
 			);


### PR DESCRIPTION
## Summary
- **Error_Log_Reader** (#48): Fixed directory traversal prefix-confusion in `is_path_safe()` by requiring a trailing directory separator in all `strpos()` prefix checks. A site at `/var/www/html` would previously accept paths under `/var/www/html-staging/`.
- **Security_Hardener** (#49): Added explicit header name allowlist and CR/LF rejection in `apply_runtime_hardening()` to prevent HTTP response splitting if the stored option is tampered with.
- **Report_History** (#50): Base64-encode gzcompressed binary data before storing with `%s` format specifier to prevent UTF-8 truncation/corruption in MySQL `utf8mb4` columns. The `decompress_report()` method now handles both new base64-encoded and legacy raw binary formats for backward compatibility.

## Test plan
- [ ] Verify `is_path_safe()` rejects paths like `/var/www/html-staging/evil.log` when ABSPATH is `/var/www/html`
- [ ] Verify `apply_runtime_hardening()` only emits headers in the allowlist
- [ ] Verify `apply_runtime_hardening()` rejects header names/values containing `\r` or `\n`
- [ ] Verify `save_snapshot()` stores base64-encoded data that round-trips correctly
- [ ] Verify `decompress_report()` can still read legacy raw-binary-stored snapshots
- [ ] All CI checks pass (PHPCS, PHPStan, PHPUnit on PHP 8.1-8.4)

Fixes #48, #49, #50

## Summary by Sourcery

Address multiple security and data integrity issues across error log handling, security header emission, and report snapshot storage.

Bug Fixes:
- Tighten error log path validation to prevent directory traversal via prefix-confusion around ABSPATH, WP_CONTENT_DIR, and allowed log directories.
- Restrict runtime security header emission to an explicit allowlist and reject CR/LF in header names and values to prevent HTTP response splitting.
- Ensure compressed report snapshots are safely stored in UTF-8 database columns by base64-encoding gzcompressed data and adding backward-compatible decoding in report decompression.