### PR TITLE
Flush all collector caches on admin page load

### DIFF
--- a/includes/class-admin-page.php
+++ b/includes/class-admin-page.php
@@ -91,6 +91,9 @@ class Admin_Page {
 			wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'wp-system-report' ) );
 		}
 
+		// Flush all collector caches so the admin always sees fresh data.
+		$this->report_generator->flush_all_caches();
+
 		$sr_current_tab = $this->get_current_tab();
 
 		// Only generate the full report when on the report tab to avoid

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -289,17 +289,6 @@ class Plugin {
 		if ( Features::has_abilities() ) {
 			add_action( 'admin_notices', array( $this, 'maybe_show_mcp_adapter_notice' ) );
 		}
-
-		// Cache invalidation hooks.
-		add_action( 'switch_theme', array( $this, 'clear_theme_cache' ) );
-		add_action( 'activate_plugin', array( $this, 'clear_plugin_cache' ) );
-		add_action( 'deactivate_plugin', array( $this, 'clear_plugin_cache' ) );
-		add_action(
-			'upgrader_process_complete',
-			array( $this, 'clear_upgrade_cache' ),
-			10,
-			2
-		);
 	}
 
 	/**
@@ -410,42 +399,5 @@ class Plugin {
 		}
 
 		include WP_SYSTEM_REPORT_DIR . 'templates/mcp-adapter-notice.php';
-	}
-
-	/**
-	 * Clear theme-related caches.
-	 */
-	public function clear_theme_cache(): void {
-		delete_transient( 'sr_theme_info' );
-		delete_transient( 'sr_site_health' );
-	}
-
-	/**
-	 * Clear plugin-related caches.
-	 */
-	public function clear_plugin_cache(): void {
-		delete_transient( 'sr_active_plugins' );
-		delete_transient( 'sr_inactive_plugins' );
-		delete_transient( 'sr_dropins_mu_plugins' );
-		delete_transient( 'sr_site_health' );
-	}
-
-	/**
-	 * Clear caches after upgrades.
-	 *
-	 * @param \WP_Upgrader $upgrader Upgrader instance.
-	 * @param array        $extra    Extra data about the upgrade.
-	 */
-	public function clear_upgrade_cache( $upgrader, $extra ): void {
-		if ( empty( $extra ) || empty( $extra['type'] ) ) {
-			return;
-		}
-
-		if ( 'plugin' === $extra['type'] ) {
-			$this->clear_plugin_cache();
-			$this->clear_theme_cache();
-		} elseif ( 'theme' === $extra['type'] ) {
-			$this->clear_theme_cache();
-		}
 	}
 }

--- a/includes/class-report-generator.php
+++ b/includes/class-report-generator.php
@@ -110,6 +110,25 @@ class Report_Generator {
 	}
 
 	/**
+	 * Flush all collector caches.
+	 *
+	 * Iterates every registered collector that extends Abstract_Collector
+	 * and deletes its transient so the next generate() call returns fresh data.
+	 *
+	 * Called on the System Report admin page load to guarantee the admin
+	 * always sees current information.
+	 *
+	 * @since 2.0.0
+	 */
+	public function flush_all_caches(): void {
+		foreach ( $this->collectors as $collector ) {
+			if ( $collector instanceof Collectors\Abstract_Collector ) {
+				$collector->flush_cache();
+			}
+		}
+	}
+
+	/**
 	 * Generate data for a single collector section.
 	 *
 	 * @param string $id Collector ID.

--- a/includes/collectors/class-abstract-collector.php
+++ b/includes/collectors/class-abstract-collector.php
@@ -83,6 +83,24 @@ abstract class Abstract_Collector implements Collector {
 	}
 
 	/**
+	 * Delete the cached transient for this collector.
+	 *
+	 * Called on admin page load so the next collect() runs fresh.
+	 * No-op for collectors that do not define a cache key.
+	 *
+	 * @since 2.0.0
+	 */
+	public function flush_cache(): void {
+		$base_key = $this->get_cache_key();
+
+		if ( null === $base_key ) {
+			return;
+		}
+
+		delete_transient( $this->build_versioned_cache_key( $base_key ) );
+	}
+
+	/**
 	 * Build a Field value object with sensible defaults.
 	 *
 	 * Accepts both Status enum instances and legacy string values

--- a/tests/CollectorsTest.php
+++ b/tests/CollectorsTest.php
@@ -570,4 +570,53 @@ class CollectorsTest extends WP_UnitTestCase {
 
 		delete_transient( sr_versioned_cache_key( 'sr_network_connectivity' ) );
 	}
+
+	// -------------------------------------------------------
+	// flush_cache() tests.
+	// -------------------------------------------------------
+
+	/**
+	 * Test that flush_cache deletes the versioned transient.
+	 */
+	public function test_flush_cache_deletes_versioned_transient() {
+		$collector = $this->collectors['site_health'];
+		$cache_key = sr_versioned_cache_key( 'sr_site_health' );
+
+		// Prime the cache.
+		$collector->get_cached_data();
+		$this->assertNotFalse( get_transient( $cache_key ), 'Transient should exist after caching.' );
+
+		// Flush and verify.
+		$collector->flush_cache();
+		$this->assertFalse( get_transient( $cache_key ), 'Transient should be deleted after flush.' );
+	}
+
+	/**
+	 * Test that flush_cache is a no-op for uncached collectors.
+	 */
+	public function test_flush_cache_noop_for_uncached_collectors() {
+		$collector = $this->collectors['wordpress_environment'];
+
+		// Should not throw — uncached collectors return null from get_cache_key().
+		$collector->flush_cache();
+		$this->assertTrue( true, 'flush_cache completed without error for uncached collector.' );
+	}
+
+	/**
+	 * Test that get_cached_data returns fresh data after flush_cache.
+	 */
+	public function test_get_cached_data_returns_fresh_after_flush() {
+		$collector = $this->collectors['post_type_counts'];
+		$cache_key = sr_versioned_cache_key( 'sr_post_type_counts' );
+
+		// Prime with sentinel data.
+		set_transient( $cache_key, array( 'sentinel' => true ), HOUR_IN_SECONDS );
+		$stale = $collector->get_cached_data();
+		$this->assertArrayHasKey( 'sentinel', $stale, 'Should return stale sentinel data from cache.' );
+
+		// Flush and re-collect — should be fresh (no sentinel key).
+		$collector->flush_cache();
+		$fresh = $collector->get_cached_data();
+		$this->assertArrayNotHasKey( 'sentinel', $fresh, 'Should return fresh data after flush.' );
+	}
 }

--- a/tests/ReportGeneratorTest.php
+++ b/tests/ReportGeneratorTest.php
@@ -214,6 +214,85 @@ class ReportGeneratorTest extends WP_UnitTestCase {
 		$this->assertSame( 'Second', $collectors['dupe']->get_label() );
 	}
 
+	// -------------------------------------------------------
+	// Cache flush tests.
+	// -------------------------------------------------------
+
+	/**
+	 * Test that flush_all_caches deletes transients for cached collectors.
+	 */
+	public function test_flush_all_caches_deletes_transients(): void {
+		$collector = new \SystemReport\Collectors\Site_Health();
+		$this->generator->register_collector( $collector );
+
+		// Prime the cache.
+		$collector->get_cached_data();
+		$cache_key = sr_versioned_cache_key( 'sr_site_health' );
+		$this->assertNotFalse( get_transient( $cache_key ), 'Transient should exist after priming.' );
+
+		// Flush and verify it's gone.
+		$this->generator->flush_all_caches();
+		$this->assertFalse( get_transient( $cache_key ), 'Transient should be deleted after flush.' );
+	}
+
+	/**
+	 * Test that flush_all_caches safely skips interface-only collectors.
+	 */
+	public function test_flush_all_caches_skips_interface_only_collectors(): void {
+		$mock = $this->create_mock_collector( 'plain', 'Plain', '', 10 );
+		$this->generator->register_collector( $mock );
+
+		// Should not throw — interface-only collectors have no flush_cache().
+		$this->generator->flush_all_caches();
+		$this->assertTrue( true, 'flush_all_caches completed without error.' );
+	}
+
+	/**
+	 * Test that generate returns fresh data after a flush.
+	 */
+	public function test_generate_returns_fresh_data_after_flush(): void {
+		$collector = new \SystemReport\Collectors\Post_Type_Counts();
+		$this->generator->register_collector( $collector );
+
+		$cache_key = sr_versioned_cache_key( 'sr_post_type_counts' );
+
+		// Prime with stale sentinel data.
+		set_transient( $cache_key, array( 'stale' => true ), HOUR_IN_SECONDS );
+		$stale_report = $this->generator->generate();
+		$this->assertArrayHasKey( 'stale', $stale_report['post_type_counts']['fields'] );
+
+		// Flush and re-generate — should no longer contain sentinel.
+		$this->generator->flush_all_caches();
+		$fresh_report = $this->generator->generate();
+		$this->assertArrayNotHasKey( 'stale', $fresh_report['post_type_counts']['fields'] );
+	}
+
+	/**
+	 * Test that flush_all_caches handles a mix of cached and uncached collectors.
+	 */
+	public function test_flush_all_caches_handles_mixed_collectors(): void {
+		// Cached collector.
+		$cached = new \SystemReport\Collectors\Site_Health();
+		$this->generator->register_collector( $cached );
+
+		// Uncached collector.
+		$uncached = new \SystemReport\Collectors\WordPress_Environment();
+		$this->generator->register_collector( $uncached );
+
+		// Interface-only mock.
+		$mock = $this->create_mock_collector( 'mock', 'Mock', '', 50 );
+		$this->generator->register_collector( $mock );
+
+		// Prime the cached collector.
+		$cached->get_cached_data();
+		$cache_key = sr_versioned_cache_key( 'sr_site_health' );
+		$this->assertNotFalse( get_transient( $cache_key ) );
+
+		// Flush should handle all three gracefully.
+		$this->generator->flush_all_caches();
+		$this->assertFalse( get_transient( $cache_key ), 'Cached collector transient should be deleted.' );
+	}
+
 	/**
 	 * Create a mock collector.
 	 *


### PR DESCRIPTION
## Summary

- The System Report admin page now **always shows fresh data** by flushing all collector transients before generating the report
- Removes the broken event-based cache hooks (`switch_theme`, `activate_plugin`, `upgrader_process_complete`) from `Plugin` — these were using non-versioned transient keys after PR #92 made all keys versioned, so they were silently doing nothing
- Adds `Abstract_Collector::flush_cache()` and `Report_Generator::flush_all_caches()` as the clean public API for cache invalidation
- REST API / WP-CLI consumers still benefit from the 1-hour TTL between admin page views

## Changes

| File | Change |
|------|--------|
| `class-abstract-collector.php` | New `flush_cache()` method — deletes the collector's versioned transient |
| `class-report-generator.php` | New `flush_all_caches()` method — iterates all collectors and flushes |
| `class-admin-page.php` | Calls `flush_all_caches()` at the top of `render_page()` |
| `class-plugin.php` | Removes broken `clear_theme_cache()`, `clear_plugin_cache()`, `clear_upgrade_cache()` and their hook registrations |
| `tests/ReportGeneratorTest.php` | 4 new tests for `flush_all_caches()` |
| `tests/CollectorsTest.php` | 3 new tests for `flush_cache()` |

## Test plan

- [ ] PHPCS passes across PHP 8.1–8.4
- [ ] PHPStan passes with 0 errors
- [ ] PHPUnit passes across PHP 8.1–8.4
- [ ] Rector dry-run passes
- [ ] Sourcery review passes
- [ ] Verify on live site: visit System Report → data reflects current state (not cached)

## Summary by Sourcery

Ensure the System Report admin page always displays fresh collector data by adding explicit cache-flush APIs and removing obsolete cache invalidation hooks.

New Features:
- Introduce a public flush_cache() API on collectors to clear their versioned transients.
- Add a Report_Generator::flush_all_caches() method to invalidate all collector caches in one call.

Bug Fixes:
- Remove broken cache invalidation hooks in the plugin bootstrap that were still targeting non-versioned transient keys.

Enhancements:
- Flush all collector caches on System Report admin page load so the generated report always reflects current system state.

Tests:
- Add unit tests covering collector flush_cache() behavior for cached and uncached collectors and ensuring fresh data after a flush.
- Add unit tests for Report_Generator::flush_all_caches(), including mixed collector types and post-flush report freshness.