### PR TITLE
Remove deprecated print_client_interactivity_data call on WP 6.7+

### DIFF
--- a/includes/class-admin-page.php
+++ b/includes/class-admin-page.php
@@ -30,8 +30,6 @@ class Admin_Page {
 
 	/**
 	 * Report generator instance.
-	 *
-	 * @var \SystemReport\Report_Generator
 	 */
 	private \SystemReport\Report_Generator $report_generator;
 
@@ -151,11 +149,24 @@ class Admin_Page {
 		// WP 6.7+ automatically prints Interactivity API state in admin_footer,
 		// so the manual hook is only needed for WP 6.5–6.6.x.
 		// print_client_interactivity_data() was deprecated in WP 6.7.0 (#96).
-		if ( function_exists( 'wp_interactivity' )
-			&& version_compare( $GLOBALS['wp_version'], '6.7', '<' )
-		) {
+		if ( $this->should_register_interactivity_compat() ) {
 			add_action( 'admin_footer', array( wp_interactivity(), 'print_client_interactivity_data' ), 8 );
 		}
+	}
+
+	/**
+	 * Whether to register the legacy print_client_interactivity_data hook.
+	 *
+	 * Returns true only on WordPress 6.5–6.6.x, where the Interactivity API
+	 * does not automatically output state in admin_footer. The hook was
+	 * deprecated in WordPress 6.7.0.
+	 *
+	 * @since 1.0.0
+	 * @return bool True if the compat hook should be registered.
+	 */
+	private function should_register_interactivity_compat(): bool {
+		return function_exists( 'wp_interactivity' )
+			&& version_compare( $GLOBALS['wp_version'], '6.7', '<' );
 	}
 
 	/**

--- a/includes/class-admin-page.php
+++ b/includes/class-admin-page.php
@@ -30,6 +30,8 @@ class Admin_Page {
 
 	/**
 	 * Report generator instance.
+	 *
+	 * @var \SystemReport\Report_Generator
 	 */
 	private \SystemReport\Report_Generator $report_generator;
 
@@ -116,7 +118,7 @@ class Admin_Page {
 	 */
 	private function enqueue_interactivity_assets( string $current_tab ): void {
 		// Script Modules API (WP 6.5+) uses array-of-arrays format, not flat strings.
-		// @see https://developer.wordpress.org/reference/functions/wp_enqueue_script_module/
+		// See https://developer.wordpress.org/reference/functions/wp_enqueue_script_module/.
 		$iapi_dep = array( array( 'id' => '@wordpress/interactivity' ) );
 
 		if ( 'report' === $current_tab ) {
@@ -146,9 +148,12 @@ class Admin_Page {
 			);
 		}
 
-		// The Interactivity API state printer hooks into wp_footer by default.
-		// Admin pages use admin_footer, so we add the hook manually.
-		if ( function_exists( 'wp_interactivity' ) ) {
+		// WP 6.7+ automatically prints Interactivity API state in admin_footer,
+		// so the manual hook is only needed for WP 6.5–6.6.x.
+		// print_client_interactivity_data() was deprecated in WP 6.7.0 (#96).
+		if ( function_exists( 'wp_interactivity' )
+			&& version_compare( $GLOBALS['wp_version'], '6.7', '<' )
+		) {
 			add_action( 'admin_footer', array( wp_interactivity(), 'print_client_interactivity_data' ), 8 );
 		}
 	}

--- a/tests/AdminPageTest.php
+++ b/tests/AdminPageTest.php
@@ -1,0 +1,192 @@
+<?php
+/**
+ * Tests for Admin_Page Interactivity API hook gating.
+ *
+ * Verifies that the deprecated print_client_interactivity_data hook is only
+ * registered on WordPress < 6.7, where WordPress does not automatically print
+ * Interactivity API state in admin_footer.
+ *
+ * @package SystemReport
+ * @since 1.0.0
+ */
+
+use SystemReport\Admin_Page;
+use SystemReport\Report_Generator;
+
+/**
+ * Admin_Page tests.
+ */
+class AdminPageTest extends WP_UnitTestCase {
+
+	/**
+	 * Original WordPress version restored after each test.
+	 *
+	 * @var string
+	 */
+	private string $original_wp_version;
+
+	/**
+	 * Save the original WP version before each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		$this->original_wp_version = $GLOBALS['wp_version'];
+	}
+
+	/**
+	 * Restore the original WP version and clean up any hooks after each test.
+	 */
+	public function tear_down(): void {
+		$GLOBALS['wp_version'] = $this->original_wp_version;
+		remove_all_actions( 'admin_footer' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Invoke the private enqueue_interactivity_assets() method via reflection.
+	 *
+	 * @param Admin_Page $page     The Admin_Page instance under test.
+	 * @param string     $tab      Active tab slug to pass to the method.
+	 */
+	private function invoke_enqueue_interactivity_assets( Admin_Page $page, string $tab = 'report' ): void {
+		$reflection = new ReflectionClass( $page );
+		$method     = $reflection->getMethod( 'enqueue_interactivity_assets' );
+		$method->setAccessible( true );
+		$method->invoke( $page, $tab );
+	}
+
+	/**
+	 * Build an Admin_Page instance with a mocked Report_Generator.
+	 *
+	 * @return Admin_Page
+	 */
+	private function make_admin_page(): Admin_Page {
+		$generator = $this->createMock( Report_Generator::class );
+		return new Admin_Page( $generator );
+	}
+
+	// -------------------------------------------------------
+	// print_client_interactivity_data hook-gating tests.
+	// -------------------------------------------------------
+
+	/**
+	 * On WP 6.7+, the deprecated hook must NOT be registered.
+	 *
+	 * WordPress 6.7 introduced native admin_footer support for Interactivity API
+	 * state, making print_client_interactivity_data() unnecessary and deprecated.
+	 *
+	 * @ticket 96
+	 */
+	public function test_deprecated_hook_not_added_on_wp_67_and_above(): void {
+		if ( ! function_exists( 'wp_interactivity' ) ) {
+			$this->markTestSkipped( 'wp_interactivity() not available — WP < 6.5.' );
+		}
+
+		$GLOBALS['wp_version'] = '6.7.0';
+		$page                  = $this->make_admin_page();
+
+		$this->invoke_enqueue_interactivity_assets( $page );
+
+		$this->assertFalse(
+			has_action( 'admin_footer', array( wp_interactivity(), 'print_client_interactivity_data' ) ),
+			'Deprecated print_client_interactivity_data hook must not be added on WP 6.7+.'
+		);
+	}
+
+	/**
+	 * On WP 6.9 (the site's current version), the deprecated hook must NOT be registered.
+	 *
+	 * @ticket 96
+	 */
+	public function test_deprecated_hook_not_added_on_wp_69(): void {
+		if ( ! function_exists( 'wp_interactivity' ) ) {
+			$this->markTestSkipped( 'wp_interactivity() not available — WP < 6.5.' );
+		}
+
+		$GLOBALS['wp_version'] = '6.9.4';
+		$page                  = $this->make_admin_page();
+
+		$this->invoke_enqueue_interactivity_assets( $page );
+
+		$this->assertFalse(
+			has_action( 'admin_footer', array( wp_interactivity(), 'print_client_interactivity_data' ) ),
+			'Deprecated print_client_interactivity_data hook must not be added on WP 6.9.'
+		);
+	}
+
+	/**
+	 * On WP < 6.7, the hook MUST be registered so Interactivity API state
+	 * is still printed in admin_footer (WordPress does not handle this natively).
+	 *
+	 * @ticket 96
+	 */
+	public function test_deprecated_hook_is_added_on_wp_66(): void {
+		if ( ! function_exists( 'wp_interactivity' ) ) {
+			$this->markTestSkipped( 'wp_interactivity() not available — WP < 6.5.' );
+		}
+
+		$GLOBALS['wp_version'] = '6.6.9';
+		$page                  = $this->make_admin_page();
+
+		$this->invoke_enqueue_interactivity_assets( $page );
+
+		$this->assertNotFalse(
+			has_action( 'admin_footer', array( wp_interactivity(), 'print_client_interactivity_data' ) ),
+			'print_client_interactivity_data hook must be added on WP < 6.7 to print Interactivity API state.'
+		);
+	}
+
+	/**
+	 * On WP 6.5 (initial Interactivity API stable release), the hook MUST be registered.
+	 *
+	 * @ticket 96
+	 */
+	public function test_deprecated_hook_is_added_on_wp_65(): void {
+		if ( ! function_exists( 'wp_interactivity' ) ) {
+			$this->markTestSkipped( 'wp_interactivity() not available — WP < 6.5.' );
+		}
+
+		$GLOBALS['wp_version'] = '6.5.0';
+		$page                  = $this->make_admin_page();
+
+		$this->invoke_enqueue_interactivity_assets( $page );
+
+		$this->assertNotFalse(
+			has_action( 'admin_footer', array( wp_interactivity(), 'print_client_interactivity_data' ) ),
+			'print_client_interactivity_data hook must be added on WP 6.5 to print Interactivity API state.'
+		);
+	}
+
+	/**
+	 * The version boundary must be exactly 6.7: 6.6.x adds the hook, 6.7.0 does not.
+	 *
+	 * @ticket 96
+	 */
+	public function test_version_boundary_at_67(): void {
+		if ( ! function_exists( 'wp_interactivity' ) ) {
+			$this->markTestSkipped( 'wp_interactivity() not available — WP < 6.5.' );
+		}
+
+		// Just below the boundary — hook expected.
+		$GLOBALS['wp_version'] = '6.6.99';
+		$page                  = $this->make_admin_page();
+		$this->invoke_enqueue_interactivity_assets( $page );
+
+		$this->assertNotFalse(
+			has_action( 'admin_footer', array( wp_interactivity(), 'print_client_interactivity_data' ) ),
+			'Hook must be registered on WP 6.6.99 (below the 6.7 boundary).'
+		);
+
+		// Clean up and test the exact boundary — hook NOT expected.
+		remove_all_actions( 'admin_footer' );
+
+		$GLOBALS['wp_version'] = '6.7.0';
+		$page                  = $this->make_admin_page();
+		$this->invoke_enqueue_interactivity_assets( $page );
+
+		$this->assertFalse(
+			has_action( 'admin_footer', array( wp_interactivity(), 'print_client_interactivity_data' ) ),
+			'Hook must NOT be registered on WP 6.7.0 (at the 6.7 boundary).'
+		);
+	}
+}


### PR DESCRIPTION
## Summary
- Gates the manual Interactivity API state printer hook behind a WP < 6.7 version check
- WP 6.7+ handles admin_footer Interactivity state natively, so the manual hook is unnecessary
- Eliminates the deprecation notice on every admin page load
- Closes #96

## Test plan
- [ ] PHPCS passes
- [ ] PHPStan passes
- [ ] PHPUnit passes
- [ ] No deprecation notices on WP 6.7+ admin page loads
- [ ] Interactivity API state still prints correctly (handled natively by WP 6.7+)

## Summary by Sourcery

Gate the legacy Interactivity API admin footer hook behind a WordPress version check to avoid using a deprecated function on WP 6.7+.

Bug Fixes:
- Prevent usage of the deprecated print_client_interactivity_data hook on WordPress 6.7+ while maintaining compatibility with 6.5–6.6.x.

Enhancements:
- Introduce a dedicated helper to decide when to register the Interactivity API compatibility hook based on the current WordPress version.

Tests:
- Add unit tests covering Interactivity API admin_footer hook registration behavior across WordPress 6.5, 6.6.x, 6.7+, and the exact 6.7 version boundary.