### PR TITLE
Guard against missing WPConfigTransformer class

### DIFF
--- a/includes/class-debug-toggle.php
+++ b/includes/class-debug-toggle.php
@@ -9,13 +9,16 @@ namespace SystemReport;
 
 defined( 'ABSPATH' ) || exit;
 
-use WPConfigTransformer;
-
 /**
  * Toggles WP_DEBUG, WP_DEBUG_LOG, and WP_DEBUG_DISPLAY in wp-config.php.
  *
  * Uses the wp-cli/wp-config-transformer library for safe, regex-based editing
  * of wp-config.php. Creates a backup before every write operation.
+ *
+ * When the WPConfigTransformer class is not available (e.g. in environments
+ * where the wp-cli/wp-config-transformer package is not loaded), all read
+ * operations degrade gracefully to a read-only state and all write operations
+ * return an error string rather than throwing a fatal error.
  */
 class Debug_Toggle {
 
@@ -48,6 +51,21 @@ class Debug_Toggle {
 	}
 
 	/**
+	 * Check whether the WPConfigTransformer class is available.
+	 *
+	 * The wp-cli/wp-config-transformer package is required for reading and
+	 * writing debug constants. When it is absent (e.g. in a plain WordPress
+	 * REST API request without WP-CLI loaded) this method returns false so
+	 * that callers can degrade gracefully instead of fataling.
+	 *
+	 * @since 1.2.0
+	 * @return bool True if WPConfigTransformer can be instantiated.
+	 */
+	public function is_transformer_available(): bool {
+		return class_exists( 'WPConfigTransformer' );
+	}
+
+	/**
 	 * Check whether wp-config.php can be modified.
 	 *
 	 * Returns false if:
@@ -75,6 +93,10 @@ class Debug_Toggle {
 	 *
 	 * Reads the actual constant definitions from the file, not the runtime values.
 	 *
+	 * When WPConfigTransformer is not available, returns a state with all
+	 * constant values set to null and can_modify set to false to signal that
+	 * the environment is read-only from the perspective of this class.
+	 *
 	 * @return array{wp_debug: bool|null, wp_debug_log: bool|string|null, wp_debug_display: bool|null, can_modify: bool}
 	 */
 	public function get_state(): array {
@@ -85,12 +107,17 @@ class Debug_Toggle {
 			'can_modify'       => $this->can_modify(),
 		);
 
+		if ( ! $this->is_transformer_available() ) {
+			$state['can_modify'] = false;
+			return $state;
+		}
+
 		if ( ! file_exists( $this->config_path ) ) {
 			return $state;
 		}
 
 		try {
-			$transformer = new WPConfigTransformer( $this->config_path );
+			$transformer = new \WPConfigTransformer( $this->config_path );
 
 			if ( $transformer->exists( 'constant', 'WP_DEBUG' ) ) {
 				$state['wp_debug'] = $this->parse_bool_value(
@@ -130,6 +157,10 @@ class Debug_Toggle {
 	 * @return bool|string True on success, error message string on failure.
 	 */
 	public function enable_debug() {
+		if ( ! $this->is_transformer_available() ) {
+			return __( 'Cannot modify wp-config.php: WPConfigTransformer class is not available.', 'wp-system-report' );
+		}
+
 		if ( ! $this->can_modify() ) {
 			return __( 'wp-config.php is not writable or file modifications are disabled.', 'wp-system-report' );
 		}
@@ -154,7 +185,7 @@ class Debug_Toggle {
 		}
 
 		try {
-			$transformer = new WPConfigTransformer( $this->config_path );
+			$transformer = new \WPConfigTransformer( $this->config_path );
 			$raw_option  = array( 'raw' => true );
 
 			$this->update_or_add( $transformer, 'WP_DEBUG', 'true', $raw_option );
@@ -196,6 +227,10 @@ class Debug_Toggle {
 	 * @return bool|string True on success, error message string on failure.
 	 */
 	public function disable_debug() {
+		if ( ! $this->is_transformer_available() ) {
+			return __( 'Cannot modify wp-config.php: WPConfigTransformer class is not available.', 'wp-system-report' );
+		}
+
 		if ( ! $this->can_modify() ) {
 			return __( 'wp-config.php is not writable or file modifications are disabled.', 'wp-system-report' );
 		}
@@ -215,7 +250,7 @@ class Debug_Toggle {
 		}
 
 		try {
-			$transformer = new WPConfigTransformer( $this->config_path );
+			$transformer = new \WPConfigTransformer( $this->config_path );
 			$raw_option  = array( 'raw' => true );
 
 			$this->update_or_add( $transformer, 'WP_DEBUG', 'false', $raw_option );
@@ -243,12 +278,12 @@ class Debug_Toggle {
 	/**
 	 * Update a constant if it exists, or add it if it doesn't.
 	 *
-	 * @param WPConfigTransformer $transformer Config transformer instance.
-	 * @param string              $name        Constant name.
-	 * @param string              $value       Constant value.
-	 * @param array               $options     Transformer options.
+	 * @param \WPConfigTransformer $transformer Config transformer instance.
+	 * @param string               $name        Constant name.
+	 * @param string               $value       Constant value.
+	 * @param array                $options     Transformer options.
 	 */
-	private function update_or_add( WPConfigTransformer $transformer, string $name, string $value, array $options ): void {
+	private function update_or_add( \WPConfigTransformer $transformer, string $name, string $value, array $options ): void {
 		if ( $transformer->exists( 'constant', $name ) ) {
 			$transformer->update( 'constant', $name, $value, $options );
 		} else {
@@ -309,8 +344,8 @@ class Debug_Toggle {
 	}
 
 	/**
- * Delete the backup file after a successful operation.
- */
+	 * Delete the backup file after a successful operation.
+	 */
 	private function delete_backup(): void {
 		$backup_path = $this->get_backup_path();
 
@@ -376,10 +411,10 @@ class Debug_Toggle {
 	}
 
 	/**
- * Release a previously acquired file lock.
- *
- * @param resource $handle File handle from acquire_lock().
- */
+	 * Release a previously acquired file lock.
+	 *
+	 * @param resource $handle File handle from acquire_lock().
+	 */
 	private function release_lock( $handle ): void {
 		flock( $handle, LOCK_UN );
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose

--- a/includes/class-debug-toggle.php
+++ b/includes/class-debug-toggle.php
@@ -62,7 +62,7 @@ class Debug_Toggle {
 	 * @return bool True if WPConfigTransformer can be instantiated.
 	 */
 	public function is_transformer_available(): bool {
-		return class_exists( 'WPConfigTransformer' );
+		return class_exists( '\WPConfigTransformer' );
 	}
 
 	/**
@@ -100,17 +100,21 @@ class Debug_Toggle {
 	 * @return array{wp_debug: bool|null, wp_debug_log: bool|string|null, wp_debug_display: bool|null, can_modify: bool}
 	 */
 	public function get_state(): array {
+		if ( ! $this->is_transformer_available() ) {
+			return array(
+				'wp_debug'         => null,
+				'wp_debug_log'     => null,
+				'wp_debug_display' => null,
+				'can_modify'       => false,
+			);
+		}
+
 		$state = array(
 			'wp_debug'         => null,
 			'wp_debug_log'     => null,
 			'wp_debug_display' => null,
 			'can_modify'       => $this->can_modify(),
 		);
-
-		if ( ! $this->is_transformer_available() ) {
-			$state['can_modify'] = false;
-			return $state;
-		}
 
 		if ( ! file_exists( $this->config_path ) ) {
 			return $state;
@@ -158,7 +162,7 @@ class Debug_Toggle {
 	 */
 	public function enable_debug() {
 		if ( ! $this->is_transformer_available() ) {
-			return __( 'Cannot modify wp-config.php: WPConfigTransformer class is not available.', 'wp-system-report' );
+			return $this->transformer_unavailable_error();
 		}
 
 		if ( ! $this->can_modify() ) {
@@ -228,7 +232,7 @@ class Debug_Toggle {
 	 */
 	public function disable_debug() {
 		if ( ! $this->is_transformer_available() ) {
-			return __( 'Cannot modify wp-config.php: WPConfigTransformer class is not available.', 'wp-system-report' );
+			return $this->transformer_unavailable_error();
 		}
 
 		if ( ! $this->can_modify() ) {
@@ -273,6 +277,20 @@ class Debug_Toggle {
 		do_action( 'wp_system_report_after_debug_toggle', false, $this->config_path );
 
 		return true;
+	}
+
+	/**
+	 * Return the error message for a missing WPConfigTransformer.
+	 *
+	 * Centralizes the translatable string so it only appears once in the
+	 * codebase, satisfying i18n tooling which requires string literals inside
+	 * translation function calls.
+	 *
+	 * @since 1.2.0
+	 * @return string Translated error message.
+	 */
+	private function transformer_unavailable_error(): string {
+		return __( 'Cannot modify wp-config.php: WPConfigTransformer class is not available.', 'wp-system-report' );
 	}
 
 	/**

--- a/tests/DebugToggleTest.php
+++ b/tests/DebugToggleTest.php
@@ -51,7 +51,7 @@ class DebugToggleTest extends WP_UnitTestCase {
 	private function create_temp_config( string $extra_content = '' ): string {
 		$this->temp_config = tempnam( sys_get_temp_dir(), 'sr_test_wpconfig_' );
 
-		$config = "<?php\n";
+		$config  = "<?php\n";
 		$config .= "define( 'DB_NAME', 'test_db' );\n";
 		$config .= "define( 'DB_USER', 'root' );\n";
 		$config .= "define( 'DB_PASSWORD', '' );\n";
@@ -131,7 +131,7 @@ class DebugToggleTest extends WP_UnitTestCase {
 	 * Test get_state reads existing constants.
 	 */
 	public function test_get_state_with_constants(): void {
-		$extra = "define( 'WP_DEBUG', true );\n";
+		$extra  = "define( 'WP_DEBUG', true );\n";
 		$extra .= "define( 'WP_DEBUG_LOG', true );\n";
 		$extra .= "define( 'WP_DEBUG_DISPLAY', false );";
 
@@ -547,5 +547,136 @@ class DebugToggleTest extends WP_UnitTestCase {
 
 		// The old-style .bak file next to wp-config.php must not exist.
 		$this->assertFileDoesNotExist( $path . '.bak' );
+	}
+
+	// ---------------------------------------------------------------
+	// WPConfigTransformer availability guard tests
+	// ---------------------------------------------------------------
+
+	/**
+	 * Test is_transformer_available returns true in the test environment.
+	 *
+	 * The wp-cli/wp-config-transformer package is loaded via Composer in the
+	 * test suite, so this should always be true during normal test runs.
+	 */
+	public function test_is_transformer_available_returns_true_when_class_exists(): void {
+		$toggle = new SystemReport\Debug_Toggle( '/tmp/dummy.php' );
+		$this->assertTrue( $toggle->is_transformer_available() );
+	}
+
+	/**
+	 * Test get_state returns a safe read-only state when WPConfigTransformer
+	 * is not available — without throwing a fatal error.
+	 *
+	 * Uses a test double that overrides is_transformer_available() to simulate
+	 * an environment where the class is absent (e.g. a plain REST API request).
+	 */
+	public function test_get_state_gracefully_degrades_when_transformer_unavailable(): void {
+		$path   = $this->create_temp_config();
+		$toggle = new class( $path ) extends SystemReport\Debug_Toggle {
+			/** Simulate WPConfigTransformer being absent. */
+			public function is_transformer_available(): bool {
+				return false;
+			}
+		};
+
+		$state = $toggle->get_state();
+
+		// All constant values should be null — we cannot read the file.
+		$this->assertNull( $state['wp_debug'] );
+		$this->assertNull( $state['wp_debug_log'] );
+		$this->assertNull( $state['wp_debug_display'] );
+
+		// can_modify must be false to signal the read-only / unavailable state.
+		$this->assertFalse( $state['can_modify'] );
+	}
+
+	/**
+	 * Test get_state structure is complete even when transformer is unavailable.
+	 *
+	 * The REST endpoint must not crash; it must always return an array with
+	 * all four expected keys.
+	 */
+	public function test_get_state_returns_expected_keys_when_transformer_unavailable(): void {
+		$path   = $this->create_temp_config();
+		$toggle = new class( $path ) extends SystemReport\Debug_Toggle {
+			/** Simulate WPConfigTransformer being absent. */
+			public function is_transformer_available(): bool {
+				return false;
+			}
+		};
+
+		$state = $toggle->get_state();
+
+		$this->assertArrayHasKey( 'wp_debug', $state );
+		$this->assertArrayHasKey( 'wp_debug_log', $state );
+		$this->assertArrayHasKey( 'wp_debug_display', $state );
+		$this->assertArrayHasKey( 'can_modify', $state );
+	}
+
+	/**
+	 * Test enable_debug returns an error string when WPConfigTransformer is
+	 * not available instead of throwing a fatal error.
+	 */
+	public function test_enable_debug_returns_error_string_when_transformer_unavailable(): void {
+		$path   = $this->create_temp_config();
+		$toggle = new class( $path ) extends SystemReport\Debug_Toggle {
+			/** Simulate WPConfigTransformer being absent. */
+			public function is_transformer_available(): bool {
+				return false;
+			}
+		};
+
+		$result = $toggle->enable_debug();
+
+		$this->assertIsString( $result, 'enable_debug should return an error string when WPConfigTransformer is unavailable' );
+		$this->assertStringContainsString( 'WPConfigTransformer', $result );
+	}
+
+	/**
+	 * Test disable_debug returns an error string when WPConfigTransformer is
+	 * not available instead of throwing a fatal error.
+	 */
+	public function test_disable_debug_returns_error_string_when_transformer_unavailable(): void {
+		$path   = $this->create_temp_config();
+		$toggle = new class( $path ) extends SystemReport\Debug_Toggle {
+			/** Simulate WPConfigTransformer being absent. */
+			public function is_transformer_available(): bool {
+				return false;
+			}
+		};
+
+		$result = $toggle->disable_debug();
+
+		$this->assertIsString( $result, 'disable_debug should return an error string when WPConfigTransformer is unavailable' );
+		$this->assertStringContainsString( 'WPConfigTransformer', $result );
+	}
+
+	/**
+	 * Test that after hook does NOT fire when enable_debug is blocked by
+	 * missing transformer.
+	 */
+	public function test_after_hook_not_fired_when_transformer_unavailable_on_enable(): void {
+		$path   = $this->create_temp_config();
+		$toggle = new class( $path ) extends SystemReport\Debug_Toggle {
+			/** Simulate WPConfigTransformer being absent. */
+			public function is_transformer_available(): bool {
+				return false;
+			}
+		};
+
+		$after_fired = false;
+		add_action(
+			'wp_system_report_after_debug_toggle',
+			function () use ( &$after_fired ) {
+				$after_fired = true;
+			},
+			10,
+			2
+		);
+
+		$toggle->enable_debug();
+
+		$this->assertFalse( $after_fired, 'after_debug_toggle should NOT fire when transformer is unavailable' );
 	}
 }


### PR DESCRIPTION
## Summary
- Adds class_exists guard in Debug_Toggle to prevent fatal error when WPConfigTransformer is unavailable
- Gracefully degrades to read-only state when the class cannot be loaded
- Closes #94

## Test plan
- [ ] PHPCS passes
- [ ] PHPStan passes
- [ ] PHPUnit passes
- [ ] Verify error-log status endpoint returns valid response without WPConfigTransformer

## Summary by Sourcery

Guard Debug_Toggle against missing WPConfigTransformer by introducing an availability check and safe fallbacks for read and write operations on wp-config.php debug settings.

Bug Fixes:
- Prevent fatal errors when the WPConfigTransformer class is not available by short-circuiting debug state reads and writes.

Enhancements:
- Introduce an is_transformer_available helper and a centralized, translatable error message for missing WPConfigTransformer, ensuring consistent messaging and graceful degradation to a read-only state.
- Adjust type hints and namespacing for WPConfigTransformer usage to rely on the fully qualified class name.

Tests:
- Add coverage to ensure Debug_Toggle reports a read-only state, returns error strings, and does not fire side-effect hooks when WPConfigTransformer is unavailable, while confirming normal behavior when it is present.